### PR TITLE
[Setting] Auto-Assigner를 통해 reviewer를 자동 할당합니다.

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,25 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: false
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers: 
+  - compuTasha
+  - EuniceNam
+  - GODNOEL
+  - manju-minji
+  - taehyeonk
+  - siro96-01
+  - skycat0212
+  - Somin-DS
+  - unuhqueen
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it 
+skipKeywords:
+  - wip
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0


### PR DESCRIPTION
## 관련 이슈
- close #15 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 배경
리뷰어를 추가하는 과정이 번거로워서
[`auto-assign`](https://github.com/apps/auto-assign)을 적용해 자동으로 리뷰어를 추가하도록 구현했습니다

PR을 만들면 `auto-assign` 봇이 알아서 reviewer를 지정해주기 때문에
Reviewers 칸을 비워둔 상태로 PR을 만들면 됩니다.
<!-- PR과 관련된 논의 쓰레드, 디자인 가이드, 관련 PR 링크 등을 적어주세요 -->

## 작업 내용
현재 repo에 `auto-assign` 접근 권한을 준 상태고
`.github/auto-assign.yml` 파일을 만들어 9명 리뷰어를 추가했습니다.

<!-- PR 작성 이유와 어떤 변경이 있었는지를 포함합니다. PR에 많은 변경이 있는 경우 추가되는 클래스들의 구조나 동작 등 자세하게 적는 경우도 있습니다 -->


## 리뷰 노트
각자 `.github/auto-assign.yml` 파일에서 유저명이 맞는지 확인해주세요!
<!-- 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술합니다. 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트를 요청하는 경우에 작성합니다. -->

## 스크린샷
PR을 만들면 아래처럼 봇이 리뷰어를 추가해줍니다.
<img width="800" alt="image" src="https://user-images.githubusercontent.com/51108729/199482861-04330204-f8b0-4b25-9f7b-65d68c243509.png">
<!-- 화면 전환이나 인터랙션이 있는 경우 GIF를, 정적인 화면이라면 스크린샷을 첨부합니다. -->



