### PR TITLE
[Design] 밴드 정보 영역의 레이아웃을 구현했습니다.

### DIFF
--- a/GetARock/GetARock.xcodeproj/project.pbxproj
+++ b/GetARock/GetARock.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		07D7DA4129108D0500479B6F /* MyPage.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 07D7DA4029108D0500479B6F /* MyPage.storyboard */; };
 		07D7DA4429108DCB00479B6F /* SampleView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 07D7DA4329108DCB00479B6F /* SampleView.xib */; };
 		07D7DA832911EB7D00479B6F /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 07D7DA822911EB7D00479B6F /* .swiftlint.yml */; };
+		3D0ED2232928667900AE320C /* BandInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0ED2222928667900AE320C /* BandInfoViewController.swift */; };
+		3D565329292855E9003D0C9F /* BandInfo.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3D565328292855E9003D0C9F /* BandInfo.storyboard */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -67,6 +69,8 @@
 		07D7DA4029108D0500479B6F /* MyPage.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MyPage.storyboard; sourceTree = "<group>"; };
 		07D7DA4329108DCB00479B6F /* SampleView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SampleView.xib; sourceTree = "<group>"; };
 		07D7DA822911EB7D00479B6F /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		3D0ED2222928667900AE320C /* BandInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandInfoViewController.swift; sourceTree = "<group>"; };
+		3D565328292855E9003D0C9F /* BandInfo.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = BandInfo.storyboard; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -167,6 +171,7 @@
 		07D7DA282910882D00479B6F /* Screen */ = {
 			isa = PBXGroup;
 			children = (
+				3D56532A292855F8003D0C9F /* BandInfo */,
 				07D7DA2E2910894000479B6F /* Landing */,
 				07D7DA3D29108CC600479B6F /* MyPage */,
 			);
@@ -189,6 +194,7 @@
 				07D7D9E8290FB8C200479B6F /* Landing.storyboard */,
 				07D7D9ED290FB8C400479B6F /* LaunchScreen.storyboard */,
 				07D7DA4029108D0500479B6F /* MyPage.storyboard */,
+				3D565328292855E9003D0C9F /* BandInfo.storyboard */,
 			);
 			path = Storyboards;
 			sourceTree = "<group>";
@@ -248,6 +254,14 @@
 				07D7DA4329108DCB00479B6F /* SampleView.xib */,
 			);
 			path = Xibs;
+			sourceTree = "<group>";
+		};
+		3D56532A292855F8003D0C9F /* BandInfo */ = {
+			isa = PBXGroup;
+			children = (
+				3D0ED2222928667900AE320C /* BandInfoViewController.swift */,
+			);
+			path = BandInfo;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -360,6 +374,7 @@
 				07D7DA4429108DCB00479B6F /* SampleView.xib in Resources */,
 				07D7D9EC290FB8C400479B6F /* Assets.xcassets in Resources */,
 				07D7D9EA290FB8C200479B6F /* Landing.storyboard in Resources */,
+				3D565329292855E9003D0C9F /* BandInfo.storyboard in Resources */,
 				07D7DA4129108D0500479B6F /* MyPage.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -406,6 +421,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				07D7DA3C29108C9000479B6F /* SampleView.swift in Sources */,
+				3D0ED2232928667900AE320C /* BandInfoViewController.swift in Sources */,
 				07D7DA3F29108CF800479B6F /* MyPageViewController.swift in Sources */,
 				07D7D9E3290FB8C200479B6F /* AppDelegate.swift in Sources */,
 				07D7DA3629108AB400479B6F /* ImageLiteral.swift in Sources */,

--- a/GetARock/GetARock/Global/Resource/Storyboards/BandInfo.storyboard
+++ b/GetARock/GetARock/Global/Resource/Storyboards/BandInfo.storyboard
@@ -21,27 +21,42 @@
                                 <rect key="frame" x="0.0" y="59" width="393" height="907"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="3Eq-ag-zpn">
-                                        <rect key="frame" x="0.0" y="0.0" width="393" height="900"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="902"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nok-7l-ToW">
                                                 <rect key="frame" x="0.0" y="0.0" width="393" height="300"/>
-                                                <color key="backgroundColor" systemColor="systemMintColor"/>
+                                                <color key="backgroundColor" red="0.34901960784313724" green="0.36862745098039218" blue="0.47058823529411764" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="tintColor" white="0.63" alpha="1" colorSpace="calibratedWhite"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="300" id="5O4-5R-sr2"/>
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="duz-Ha-FXN">
-                                                <rect key="frame" x="0.0" y="300" width="393" height="300"/>
-                                                <color key="backgroundColor" systemColor="systemOrangeColor"/>
+                                                <rect key="frame" x="0.0" y="300" width="393" height="1"/>
+                                                <color key="backgroundColor" red="0.52941176470588236" green="0.55686274509803924" blue="0.68235294117647061" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="300" id="Bo9-RP-RjW"/>
+                                                    <constraint firstAttribute="height" constant="1" id="Bo9-RP-RjW"/>
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hjh-NR-swH">
-                                                <rect key="frame" x="0.0" y="600" width="393" height="300"/>
-                                                <color key="backgroundColor" systemColor="systemPinkColor"/>
+                                                <rect key="frame" x="0.0" y="301" width="393" height="300"/>
+                                                <color key="backgroundColor" red="0.34901960784313724" green="0.36862745098039218" blue="0.47058823529411764" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="300" id="XNk-pR-n38"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a7t-S3-psV">
+                                                <rect key="frame" x="0.0" y="601" width="393" height="1"/>
+                                                <color key="backgroundColor" red="0.52941176470588236" green="0.55686274509803924" blue="0.68235294117647061" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="1" id="W5z-qu-NKr"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tPC-ri-4le">
+                                                <rect key="frame" x="0.0" y="602" width="393" height="300"/>
+                                                <color key="backgroundColor" red="0.34901960784313724" green="0.36862745098039218" blue="0.47058823529411764" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="300" id="h21-9j-rRr"/>
                                                 </constraints>
                                             </view>
                                         </subviews>
@@ -75,15 +90,6 @@
     <resources>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemMintColor">
-            <color red="0.0" green="0.7803921568627451" blue="0.74509803921568629" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="systemOrangeColor">
-            <color red="1" green="0.58431372549019611" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="systemPinkColor">
-            <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/GetARock/GetARock/Global/Resource/Storyboards/BandInfo.storyboard
+++ b/GetARock/GetARock/Global/Resource/Storyboards/BandInfo.storyboard
@@ -20,116 +20,51 @@
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f7b-Qa-gAc">
                                 <rect key="frame" x="0.0" y="59" width="393" height="907"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="3Eq-ag-zpn">
-                                        <rect key="frame" x="0.0" y="0.0" width="393" height="902"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="8kK-3T-isV">
+                                        <rect key="frame" x="16" y="0.0" width="361" height="602"/>
                                         <subviews>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nok-7l-ToW">
-                                                <rect key="frame" x="0.0" y="0.0" width="393" height="300"/>
-                                                <color key="backgroundColor" red="0.34901960784313724" green="0.36862745098039218" blue="0.47058823529411764" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <color key="tintColor" white="0.63" alpha="1" colorSpace="calibratedWhite"/>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Mur-44-ftU">
+                                                <rect key="frame" x="0.0" y="0.0" width="361" height="200"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="300" id="5O4-5R-sr2"/>
+                                                    <constraint firstAttribute="height" constant="200" id="WIZ-Pa-EUX"/>
                                                 </constraints>
                                             </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="duz-Ha-FXN">
-                                                <rect key="frame" x="0.0" y="300" width="393" height="1"/>
-                                                <subviews>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="c3K-w1-3gZ">
-                                                        <rect key="frame" x="0.0" y="0.0" width="393" height="1"/>
-                                                        <subviews>
-                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TRg-ip-VlF">
-                                                                <rect key="frame" x="0.0" y="0.0" width="16" height="1"/>
-                                                                <color key="backgroundColor" red="0.34901960780000002" green="0.36862745099999999" blue="0.47058823529999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="width" constant="16" id="FMr-n2-LSk"/>
-                                                                </constraints>
-                                                            </view>
-                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mHw-Cm-Loy">
-                                                                <rect key="frame" x="16" y="0.0" width="361" height="1"/>
-                                                                <color key="backgroundColor" red="0.52941176469999995" green="0.5568627451" blue="0.68235294120000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                            </view>
-                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rPh-IL-J2P">
-                                                                <rect key="frame" x="377" y="0.0" width="16" height="1"/>
-                                                                <color key="backgroundColor" red="0.34901960780000002" green="0.36862745099999999" blue="0.47058823529999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="width" constant="16" id="Jh5-P1-fxb"/>
-                                                                </constraints>
-                                                            </view>
-                                                        </subviews>
-                                                    </stackView>
-                                                </subviews>
-                                                <color key="backgroundColor" red="0.52941176470588236" green="0.55686274509803924" blue="0.68235294117647061" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="1" id="Bo9-RP-RjW"/>
-                                                    <constraint firstItem="c3K-w1-3gZ" firstAttribute="top" secondItem="duz-Ha-FXN" secondAttribute="top" id="DKZ-zp-VvU"/>
-                                                    <constraint firstAttribute="bottom" secondItem="c3K-w1-3gZ" secondAttribute="bottom" id="Rcv-03-d1K"/>
-                                                    <constraint firstAttribute="trailing" secondItem="c3K-w1-3gZ" secondAttribute="trailing" id="Tzr-dM-OSN"/>
-                                                    <constraint firstItem="c3K-w1-3gZ" firstAttribute="height" secondItem="duz-Ha-FXN" secondAttribute="height" id="amM-f2-7qK"/>
-                                                    <constraint firstItem="c3K-w1-3gZ" firstAttribute="width" secondItem="duz-Ha-FXN" secondAttribute="width" id="mCH-zM-IXu"/>
-                                                    <constraint firstItem="c3K-w1-3gZ" firstAttribute="leading" secondItem="duz-Ha-FXN" secondAttribute="leading" id="pHR-Ge-E7E"/>
-                                                </constraints>
-                                            </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hjh-NR-swH">
-                                                <rect key="frame" x="0.0" y="301" width="393" height="300"/>
-                                                <color key="backgroundColor" red="0.34901960784313724" green="0.36862745098039218" blue="0.47058823529411764" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="300" id="XNk-pR-n38"/>
-                                                </constraints>
-                                            </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fZ5-52-aCT">
-                                                <rect key="frame" x="0.0" y="601" width="393" height="1"/>
-                                                <subviews>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iW5-8K-7tQ">
-                                                        <rect key="frame" x="0.0" y="0.0" width="393" height="1"/>
-                                                        <subviews>
-                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BID-3D-AI9">
-                                                                <rect key="frame" x="0.0" y="0.0" width="16" height="1"/>
-                                                                <color key="backgroundColor" red="0.34901960780000002" green="0.36862745099999999" blue="0.47058823529999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="width" constant="16" id="omV-3A-7gk"/>
-                                                                </constraints>
-                                                            </view>
-                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gRQ-jT-Nxg">
-                                                                <rect key="frame" x="16" y="0.0" width="361" height="1"/>
-                                                                <color key="backgroundColor" red="0.52941176469999995" green="0.5568627451" blue="0.68235294120000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                            </view>
-                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hPW-vG-2td">
-                                                                <rect key="frame" x="377" y="0.0" width="16" height="1"/>
-                                                                <color key="backgroundColor" red="0.34901960780000002" green="0.36862745099999999" blue="0.47058823529999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="width" constant="16" id="iTO-wG-xNh"/>
-                                                                </constraints>
-                                                            </view>
-                                                        </subviews>
-                                                    </stackView>
-                                                </subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LiA-2d-x7E">
+                                                <rect key="frame" x="0.0" y="200" width="361" height="1"/>
                                                 <color key="backgroundColor" red="0.52941176469999995" green="0.5568627451" blue="0.68235294120000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
-                                                    <constraint firstItem="iW5-8K-7tQ" firstAttribute="width" secondItem="fZ5-52-aCT" secondAttribute="width" id="5rq-BX-HIU"/>
-                                                    <constraint firstItem="iW5-8K-7tQ" firstAttribute="height" secondItem="fZ5-52-aCT" secondAttribute="height" id="6qx-Oh-K4B"/>
-                                                    <constraint firstAttribute="height" constant="1" id="EDw-oa-tcD"/>
-                                                    <constraint firstAttribute="bottom" secondItem="iW5-8K-7tQ" secondAttribute="bottom" id="Qoa-pe-M2u"/>
-                                                    <constraint firstAttribute="trailing" secondItem="iW5-8K-7tQ" secondAttribute="trailing" id="rOZ-Sd-r57"/>
-                                                    <constraint firstItem="iW5-8K-7tQ" firstAttribute="top" secondItem="fZ5-52-aCT" secondAttribute="top" id="uLN-w3-oGV"/>
-                                                    <constraint firstItem="iW5-8K-7tQ" firstAttribute="leading" secondItem="fZ5-52-aCT" secondAttribute="leading" id="vIS-bt-zlW"/>
+                                                    <constraint firstAttribute="height" constant="1" id="UKk-GJ-H1m"/>
                                                 </constraints>
                                             </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5dB-Ot-Ayk">
-                                                <rect key="frame" x="0.0" y="602" width="393" height="300"/>
-                                                <color key="backgroundColor" red="0.34901960780000002" green="0.36862745099999999" blue="0.47058823529999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8qU-NZ-fDu">
+                                                <rect key="frame" x="0.0" y="201" width="361" height="200"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="300" id="rrZ-cS-UgI"/>
+                                                    <constraint firstAttribute="height" constant="200" id="OSc-ZC-SDl"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aL0-SH-uYF">
+                                                <rect key="frame" x="0.0" y="401" width="361" height="1"/>
+                                                <color key="backgroundColor" red="0.52941176469999995" green="0.5568627451" blue="0.68235294120000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="1" id="Mq4-Tz-FoJ"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GKK-x9-sjo">
+                                                <rect key="frame" x="0.0" y="402" width="361" height="200"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="200" id="pJO-If-sxO"/>
                                                 </constraints>
                                             </view>
                                         </subviews>
                                     </stackView>
                                 </subviews>
+                                <color key="backgroundColor" red="0.34901960780000002" green="0.36862745099999999" blue="0.47058823529999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="3Eq-ag-zpn" secondAttribute="trailing" id="3R0-dg-LNH"/>
-                                    <constraint firstItem="3Eq-ag-zpn" firstAttribute="top" secondItem="f7b-Qa-gAc" secondAttribute="top" id="3kx-YN-hKJ"/>
-                                    <constraint firstItem="3Eq-ag-zpn" firstAttribute="leading" secondItem="f7b-Qa-gAc" secondAttribute="leading" id="Ctn-1d-5B8"/>
-                                    <constraint firstAttribute="bottom" secondItem="3Eq-ag-zpn" secondAttribute="bottom" id="lgP-eQ-B1N"/>
-                                    <constraint firstItem="3Eq-ag-zpn" firstAttribute="width" secondItem="f7b-Qa-gAc" secondAttribute="width" id="yVp-0E-hHB"/>
+                                    <constraint firstItem="8kK-3T-isV" firstAttribute="leading" secondItem="f7b-Qa-gAc" secondAttribute="leading" constant="16" id="0si-5J-aRa"/>
+                                    <constraint firstItem="8kK-3T-isV" firstAttribute="top" secondItem="f7b-Qa-gAc" secondAttribute="top" id="azR-w8-OpU"/>
+                                    <constraint firstAttribute="trailing" secondItem="8kK-3T-isV" secondAttribute="trailing" constant="16" id="ley-hO-eo8"/>
+                                    <constraint firstAttribute="bottom" secondItem="8kK-3T-isV" secondAttribute="bottom" id="n5E-QM-RvP"/>
+                                    <constraint firstItem="8kK-3T-isV" firstAttribute="centerX" secondItem="f7b-Qa-gAc" secondAttribute="centerX" id="vJP-mL-Iok"/>
                                 </constraints>
                             </scrollView>
                         </subviews>

--- a/GetARock/GetARock/Global/Resource/Storyboards/BandInfo.storyboard
+++ b/GetARock/GetARock/Global/Resource/Storyboards/BandInfo.storyboard
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Band Info View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController id="Y6W-OH-hqX" customClass="BandInfoViewController" customModule="GetARock" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="1000"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f7b-Qa-gAc">
+                                <rect key="frame" x="0.0" y="59" width="393" height="907"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="3Eq-ag-zpn">
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="900"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nok-7l-ToW">
+                                                <rect key="frame" x="0.0" y="0.0" width="393" height="300"/>
+                                                <color key="backgroundColor" systemColor="systemMintColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="300" id="5O4-5R-sr2"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="duz-Ha-FXN">
+                                                <rect key="frame" x="0.0" y="300" width="393" height="300"/>
+                                                <color key="backgroundColor" systemColor="systemOrangeColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="300" id="Bo9-RP-RjW"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hjh-NR-swH">
+                                                <rect key="frame" x="0.0" y="600" width="393" height="300"/>
+                                                <color key="backgroundColor" systemColor="systemPinkColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="300" id="XNk-pR-n38"/>
+                                                </constraints>
+                                            </view>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="3Eq-ag-zpn" secondAttribute="trailing" id="3R0-dg-LNH"/>
+                                    <constraint firstItem="3Eq-ag-zpn" firstAttribute="top" secondItem="f7b-Qa-gAc" secondAttribute="top" id="3kx-YN-hKJ"/>
+                                    <constraint firstItem="3Eq-ag-zpn" firstAttribute="leading" secondItem="f7b-Qa-gAc" secondAttribute="leading" id="Ctn-1d-5B8"/>
+                                    <constraint firstAttribute="bottom" secondItem="3Eq-ag-zpn" secondAttribute="bottom" id="lgP-eQ-B1N"/>
+                                    <constraint firstItem="3Eq-ag-zpn" firstAttribute="width" secondItem="f7b-Qa-gAc" secondAttribute="width" id="yVp-0E-hHB"/>
+                                </constraints>
+                            </scrollView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="f7b-Qa-gAc" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="MkR-oo-7JE"/>
+                            <constraint firstItem="f7b-Qa-gAc" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="VhV-tV-pt0"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="f7b-Qa-gAc" secondAttribute="trailing" id="gfh-tx-9ef"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="f7b-Qa-gAc" secondAttribute="bottom" id="igK-Vk-rwZ"/>
+                        </constraints>
+                    </view>
+                    <size key="freeformSize" width="393" height="1000"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="90.839694656488547" y="-34.507042253521128"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemMintColor">
+            <color red="0.0" green="0.7803921568627451" blue="0.74509803921568629" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemOrangeColor">
+            <color red="1" green="0.58431372549019611" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemPinkColor">
+            <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/GetARock/GetARock/Global/Resource/Storyboards/BandInfo.storyboard
+++ b/GetARock/GetARock/Global/Resource/Storyboards/BandInfo.storyboard
@@ -33,9 +33,40 @@
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="duz-Ha-FXN">
                                                 <rect key="frame" x="0.0" y="300" width="393" height="1"/>
+                                                <subviews>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="c3K-w1-3gZ">
+                                                        <rect key="frame" x="0.0" y="0.0" width="393" height="1"/>
+                                                        <subviews>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TRg-ip-VlF">
+                                                                <rect key="frame" x="0.0" y="0.0" width="16" height="1"/>
+                                                                <color key="backgroundColor" red="0.34901960780000002" green="0.36862745099999999" blue="0.47058823529999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="16" id="FMr-n2-LSk"/>
+                                                                </constraints>
+                                                            </view>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mHw-Cm-Loy">
+                                                                <rect key="frame" x="16" y="0.0" width="361" height="1"/>
+                                                                <color key="backgroundColor" red="0.52941176469999995" green="0.5568627451" blue="0.68235294120000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            </view>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rPh-IL-J2P">
+                                                                <rect key="frame" x="377" y="0.0" width="16" height="1"/>
+                                                                <color key="backgroundColor" red="0.34901960780000002" green="0.36862745099999999" blue="0.47058823529999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="16" id="Jh5-P1-fxb"/>
+                                                                </constraints>
+                                                            </view>
+                                                        </subviews>
+                                                    </stackView>
+                                                </subviews>
                                                 <color key="backgroundColor" red="0.52941176470588236" green="0.55686274509803924" blue="0.68235294117647061" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="Bo9-RP-RjW"/>
+                                                    <constraint firstItem="c3K-w1-3gZ" firstAttribute="top" secondItem="duz-Ha-FXN" secondAttribute="top" id="DKZ-zp-VvU"/>
+                                                    <constraint firstAttribute="bottom" secondItem="c3K-w1-3gZ" secondAttribute="bottom" id="Rcv-03-d1K"/>
+                                                    <constraint firstAttribute="trailing" secondItem="c3K-w1-3gZ" secondAttribute="trailing" id="Tzr-dM-OSN"/>
+                                                    <constraint firstItem="c3K-w1-3gZ" firstAttribute="height" secondItem="duz-Ha-FXN" secondAttribute="height" id="amM-f2-7qK"/>
+                                                    <constraint firstItem="c3K-w1-3gZ" firstAttribute="width" secondItem="duz-Ha-FXN" secondAttribute="width" id="mCH-zM-IXu"/>
+                                                    <constraint firstItem="c3K-w1-3gZ" firstAttribute="leading" secondItem="duz-Ha-FXN" secondAttribute="leading" id="pHR-Ge-E7E"/>
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hjh-NR-swH">
@@ -45,18 +76,49 @@
                                                     <constraint firstAttribute="height" constant="300" id="XNk-pR-n38"/>
                                                 </constraints>
                                             </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a7t-S3-psV">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fZ5-52-aCT">
                                                 <rect key="frame" x="0.0" y="601" width="393" height="1"/>
-                                                <color key="backgroundColor" red="0.52941176470588236" green="0.55686274509803924" blue="0.68235294117647061" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <subviews>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iW5-8K-7tQ">
+                                                        <rect key="frame" x="0.0" y="0.0" width="393" height="1"/>
+                                                        <subviews>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BID-3D-AI9">
+                                                                <rect key="frame" x="0.0" y="0.0" width="16" height="1"/>
+                                                                <color key="backgroundColor" red="0.34901960780000002" green="0.36862745099999999" blue="0.47058823529999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="16" id="omV-3A-7gk"/>
+                                                                </constraints>
+                                                            </view>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gRQ-jT-Nxg">
+                                                                <rect key="frame" x="16" y="0.0" width="361" height="1"/>
+                                                                <color key="backgroundColor" red="0.52941176469999995" green="0.5568627451" blue="0.68235294120000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            </view>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hPW-vG-2td">
+                                                                <rect key="frame" x="377" y="0.0" width="16" height="1"/>
+                                                                <color key="backgroundColor" red="0.34901960780000002" green="0.36862745099999999" blue="0.47058823529999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="16" id="iTO-wG-xNh"/>
+                                                                </constraints>
+                                                            </view>
+                                                        </subviews>
+                                                    </stackView>
+                                                </subviews>
+                                                <color key="backgroundColor" red="0.52941176469999995" green="0.5568627451" blue="0.68235294120000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="1" id="W5z-qu-NKr"/>
+                                                    <constraint firstItem="iW5-8K-7tQ" firstAttribute="width" secondItem="fZ5-52-aCT" secondAttribute="width" id="5rq-BX-HIU"/>
+                                                    <constraint firstItem="iW5-8K-7tQ" firstAttribute="height" secondItem="fZ5-52-aCT" secondAttribute="height" id="6qx-Oh-K4B"/>
+                                                    <constraint firstAttribute="height" constant="1" id="EDw-oa-tcD"/>
+                                                    <constraint firstAttribute="bottom" secondItem="iW5-8K-7tQ" secondAttribute="bottom" id="Qoa-pe-M2u"/>
+                                                    <constraint firstAttribute="trailing" secondItem="iW5-8K-7tQ" secondAttribute="trailing" id="rOZ-Sd-r57"/>
+                                                    <constraint firstItem="iW5-8K-7tQ" firstAttribute="top" secondItem="fZ5-52-aCT" secondAttribute="top" id="uLN-w3-oGV"/>
+                                                    <constraint firstItem="iW5-8K-7tQ" firstAttribute="leading" secondItem="fZ5-52-aCT" secondAttribute="leading" id="vIS-bt-zlW"/>
                                                 </constraints>
                                             </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tPC-ri-4le">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5dB-Ot-Ayk">
                                                 <rect key="frame" x="0.0" y="602" width="393" height="300"/>
-                                                <color key="backgroundColor" red="0.34901960784313724" green="0.36862745098039218" blue="0.47058823529411764" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="backgroundColor" red="0.34901960780000002" green="0.36862745099999999" blue="0.47058823529999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="300" id="h21-9j-rRr"/>
+                                                    <constraint firstAttribute="height" constant="300" id="rrZ-cS-UgI"/>
                                                 </constraints>
                                             </view>
                                         </subviews>

--- a/GetARock/GetARock/Screen/BandInfo/BandInfoViewController.swift
+++ b/GetARock/GetARock/Screen/BandInfo/BandInfoViewController.swift
@@ -1,0 +1,28 @@
+//
+//  BandInfoViewController.swift
+//  GetARock
+//
+//  Created by Seungwon Choi on 2022/11/19.
+//
+
+import UIKit
+
+class BandInfoViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}


### PR DESCRIPTION
## 관련 이슈
- close #40 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 배경
밴드 정보 영역의 레이아웃을 구현합니다.
<!-- PR과 관련된 논의 쓰레드, 디자인 가이드, 관련 PR 링크 등을 적어주세요 -->

## 작업 내용
- 밴드 정보 영역을 밴드 멤버/합주곡/밴드 소개의 3가지 영역으로 나눴습니다.
- `Scroll View`를 활용해 Scroll 되는 밴드 영역 형태를 구현하고, 그 위에 `Stack View`를 활용해 5개의 UIView를 올렸습니다.
- 5개 중 2개의 `UIView`는 height를 1px로 줘서 구분선 형태로 사용합니다.
- 구분선 앞뒤의 여백은 `Stack View`를 활용하여 구현했습니다.
<!-- PR 작성 이유와 어떤 변경이 있었는지를 포함합니다. PR에 많은 변경이 있는 경우 추가되는 클래스들의 구조나 동작 등 자세하게 적는 경우도 있습니다 -->

## 테스트 방법
- StoryBoard 형태라서 제 브랜치로 checkout한 다음에 리뷰해주시면 감사하겠습니다.
<!-- PR 리뷰어가 이 PR의 변경사항을 확인할 수 있는 방법을 서술합니다. 의도하는 테스트 결과도 서술하면 더 좋습니다 -->

## 리뷰 노트
- `Stack View`를 활용하기 위해 `UIView` 형태로 구분선을 구현했는데 어떻게 생각하시는지 궁금합니다.
<!-- 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술합니다. 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트를 요청하는 경우에 작성합니다. -->

## 스크린샷
<img src="https://user-images.githubusercontent.com/49133245/202828832-d9d238bf-a250-44a0-87e1-f015210ba5d2.png" alt="drawing" width="300"/>
<!-- 화면 전환이나 인터랙션이 있는 경우 GIF를, 정적인 화면이라면 스크린샷을 첨부합니다. -->
<!-- <img width="" alt="" src=""> -->
