### PR TITLE
[Design] 모여락(밴드 이벤트) 추가 화면을 구현합니다.

### DIFF
--- a/GetARock/GetARock.xcodeproj/project.pbxproj
+++ b/GetARock/GetARock.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		7BDA8F90291296B200BB2D34 /* UIView+Gradation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BDA8F8F291296B200BB2D34 /* UIView+Gradation.swift */; };
 		B830849929263B780035DB2D /* MainMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B830849829263B780035DB2D /* MainMapViewController.swift */; };
 		B8B9971F29287D3700082462 /* MainMap.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B8B9971E29287D3700082462 /* MainMap.storyboard */; };
+		C5C7AC6B292A7F7C00698636 /* AddGathering.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C5C7AC6A292A7F7C00698636 /* AddGathering.storyboard */; };
+		C5C7AC6D292A7FA200698636 /* AddGatheringViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C7AC6C292A7FA200698636 /* AddGatheringViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -95,6 +97,8 @@
 		7BDA8F8F291296B200BB2D34 /* UIView+Gradation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Gradation.swift"; sourceTree = "<group>"; };
 		B830849829263B780035DB2D /* MainMapViewController.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = MainMapViewController.swift; sourceTree = "<group>"; tabWidth = 4; };
 		B8B9971E29287D3700082462 /* MainMap.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MainMap.storyboard; sourceTree = "<group>"; };
+		C5C7AC6A292A7F7C00698636 /* AddGathering.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = AddGathering.storyboard; sourceTree = "<group>"; };
+		C5C7AC6C292A7FA200698636 /* AddGatheringViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddGatheringViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -222,6 +226,7 @@
 			children = (
 				3D56532A292855F8003D0C9F /* BandInfo */,
 				B830849729263B620035DB2D /* MainMap */,
+				C5C7AC69292A7EC000698636 /* AddGathering */,
 				07D7DA2E2910894000479B6F /* Landing */,
 				07D7DA3D29108CC600479B6F /* MyPage */,
 			);
@@ -246,6 +251,7 @@
 				07D7DA4029108D0500479B6F /* MyPage.storyboard */,
 				3D565328292855E9003D0C9F /* BandInfo.storyboard */,
 				B8B9971E29287D3700082462 /* MainMap.storyboard */,
+				C5C7AC6A292A7F7C00698636 /* AddGathering.storyboard */,
 			);
 			path = Storyboards;
 			sourceTree = "<group>";
@@ -330,6 +336,14 @@
 				B830849829263B780035DB2D /* MainMapViewController.swift */,
 			);
 			path = MainMap;
+			sourceTree = "<group>";
+		};
+		C5C7AC69292A7EC000698636 /* AddGathering */ = {
+			isa = PBXGroup;
+			children = (
+				C5C7AC6C292A7FA200698636 /* AddGatheringViewController.swift */,
+			);
+			path = AddGathering;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -444,6 +458,7 @@
 				07D7D9EC290FB8C400479B6F /* Assets.xcassets in Resources */,
 				07D7D9EA290FB8C200479B6F /* Landing.storyboard in Resources */,
 				3D565329292855E9003D0C9F /* BandInfo.storyboard in Resources */,
+				C5C7AC6B292A7F7C00698636 /* AddGathering.storyboard in Resources */,
 				07D7DA4129108D0500479B6F /* MyPage.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -503,6 +518,7 @@
 				7BDA8F90291296B200BB2D34 /* UIView+Gradation.swift in Sources */,
 				0761508B29276D8200A0562F /* Coordinate.swift in Sources */,
 				07D7DA302910895000479B6F /* LandingViewController.swift in Sources */,
+				C5C7AC6D292A7FA200698636 /* AddGatheringViewController.swift in Sources */,
 				072DEDD429268F470046A4A0 /* PlayPosition.swift in Sources */,
 				07D7DA2D291088EC00479B6F /* NSObject+Extension.swift in Sources */,
 				07615093292907A900A0562F /* GatheringComment.swift in Sources */,

--- a/GetARock/GetARock/Global/Resource/Storyboards/AddGathering.storyboard
+++ b/GetARock/GetARock/Global/Resource/Storyboards/AddGathering.storyboard
@@ -1,33 +1,246 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="45C-kJ-km3">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Add Gathering View Controller-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
-                <viewController id="Y6W-OH-hqX" customClass="AddGatheringViewController" customModule="GetARock" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="AddGathering" id="Y6W-OH-hqX" customClass="AddGatheringViewController" customModule="GetARock" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="749"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="teO-Fx-L4D">
+                                <rect key="frame" x="0.0" y="0.0" width="393" height="715"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ano-jH-ByV" userLabel="scrollContentView">
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="352"/>
+                                        <subviews>
+                                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="모여락 이름" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="zaJ-zq-18Z" userLabel="GatheringTitle">
+                                                <rect key="frame" x="16" y="40" width="361" height="25.666666666666671"/>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <color key="tintColor" red="0.51372551919999998" green="0.52941179279999995" blue="0.62352943419999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uot-Mo-luY" userLabel="SeparatorView">
+                                                <rect key="frame" x="16" y="77.666666666666657" width="361" height="1"/>
+                                                <color key="backgroundColor" red="0.52941176469999995" green="0.5568627451" blue="0.68235294120000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="1" id="jEa-Px-kn1"/>
+                                                </constraints>
+                                            </view>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="주최" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hcj-qa-baG">
+                                                <rect key="frame" x="32" y="98.666666666666657" width="29.666666666666671" height="20.333333333333329"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="주최밴드명" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n7W-To-VFW">
+                                                <rect key="frame" x="81.666666666666671" y="98.666666666666657" width="65.000000000000014" height="20.333333333333329"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TJH-VW-Tct" userLabel="SeparatorView">
+                                                <rect key="frame" x="16" y="139" width="361" height="1"/>
+                                                <color key="backgroundColor" red="0.52941176469999995" green="0.5568627451" blue="0.68235294120000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="1" id="KJX-ck-h6W"/>
+                                                </constraints>
+                                            </view>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="시간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CKs-Sh-Fpq">
+                                                <rect key="frame" x="32" y="160" width="30" height="20.333333333333343"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3Th-tF-r4O" userLabel="SeparatorView">
+                                                <rect key="frame" x="16" y="200.33333333333331" width="361" height="1"/>
+                                                <color key="backgroundColor" red="0.52941176469999995" green="0.5568627451" blue="0.68235294120000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="1" id="QnS-g8-v8r"/>
+                                                </constraints>
+                                            </view>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="위치" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vd5-GS-4OI">
+                                                <rect key="frame" x="32" y="221.33333333333331" width="29.666666666666671" height="20.333333333333343"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4ni-Mb-siH" userLabel="locationTapAreaView">
+                                                <rect key="frame" x="81.666666666666657" y="200.33333333333331" width="295.33333333333337" height="62.333333333333314"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="장소를 입력해주세요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cyd-eb-cyK">
+                                                        <rect key="frame" x="0.0" y="22.333333333333371" width="121" height="18"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                        <color key="textColor" red="0.61568627450980395" green="0.63529411764705879" blue="0.74509803921568629" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="chevron.right" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="KTx-Vq-Mud">
+                                                        <rect key="frame" x="282.66666666666663" y="23" width="12.666666666666686" height="16.666666666666664"/>
+                                                        <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    </imageView>
+                                                </subviews>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstItem="cyd-eb-cyK" firstAttribute="leading" secondItem="4ni-Mb-siH" secondAttribute="leading" id="EVS-14-Rbg"/>
+                                                    <constraint firstItem="KTx-Vq-Mud" firstAttribute="centerY" secondItem="4ni-Mb-siH" secondAttribute="centerY" id="Od3-a9-f1l"/>
+                                                    <constraint firstItem="cyd-eb-cyK" firstAttribute="centerY" secondItem="4ni-Mb-siH" secondAttribute="centerY" id="S2l-4q-XkU"/>
+                                                    <constraint firstAttribute="trailing" secondItem="KTx-Vq-Mud" secondAttribute="trailing" id="kEj-TP-4OS"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xwe-Si-O3s" userLabel="SeparatorView">
+                                                <rect key="frame" x="19" y="261.66666666666669" width="361" height="1"/>
+                                                <color key="backgroundColor" red="0.52941176469999995" green="0.5568627451" blue="0.68235294120000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="1" id="xxs-YO-K2e"/>
+                                                </constraints>
+                                            </view>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="소개" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="t4V-e7-iLN">
+                                                <rect key="frame" x="32" y="282.66666666666669" width="29.666666666666671" height="20.333333333333314"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="uNV-iD-x50">
+                                                <rect key="frame" x="32" y="319" width="329" height="33"/>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <color key="tintColor" red="0.5647059083" green="0.58039218189999997" blue="0.68235301969999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                            </textView>
+                                            <datePicker contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="249" contentHorizontalAlignment="leading" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="s35-8k-0gb">
+                                                <rect key="frame" x="82" y="153" width="215" height="34.333333333333343"/>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" priority="250" constant="200" id="e3c-J5-JwX"/>
+                                                </constraints>
+                                                <locale key="locale" localeIdentifier="ko_KR"/>
+                                            </datePicker>
+                                        </subviews>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstItem="zaJ-zq-18Z" firstAttribute="top" secondItem="Ano-jH-ByV" secondAttribute="top" constant="40" id="2Ix-uj-Vg3"/>
+                                            <constraint firstAttribute="trailing" secondItem="xwe-Si-O3s" secondAttribute="trailing" constant="13" id="2So-G0-7QC"/>
+                                            <constraint firstItem="s35-8k-0gb" firstAttribute="top" relation="greaterThanOrEqual" secondItem="TJH-VW-Tct" secondAttribute="bottom" constant="4" id="3YF-T5-1Re"/>
+                                            <constraint firstAttribute="trailing" secondItem="TJH-VW-Tct" secondAttribute="trailing" constant="16" id="4Cu-4C-ewo"/>
+                                            <constraint firstAttribute="bottom" secondItem="uNV-iD-x50" secondAttribute="bottom" id="9Cx-dS-ahM"/>
+                                            <constraint firstItem="CKs-Sh-Fpq" firstAttribute="leading" secondItem="Ano-jH-ByV" secondAttribute="leading" constant="32" id="C04-yD-GWx"/>
+                                            <constraint firstItem="uot-Mo-luY" firstAttribute="leading" secondItem="Ano-jH-ByV" secondAttribute="leading" constant="16" id="CzC-TP-ozY"/>
+                                            <constraint firstItem="xwe-Si-O3s" firstAttribute="leading" secondItem="Ano-jH-ByV" secondAttribute="leading" constant="19" id="DEz-lh-FF8"/>
+                                            <constraint firstItem="TJH-VW-Tct" firstAttribute="leading" secondItem="Ano-jH-ByV" secondAttribute="leading" constant="16" id="DIl-MI-cgL"/>
+                                            <constraint firstItem="s35-8k-0gb" firstAttribute="centerY" secondItem="CKs-Sh-Fpq" secondAttribute="centerY" id="EgH-dp-Oiv"/>
+                                            <constraint firstItem="uot-Mo-luY" firstAttribute="top" secondItem="zaJ-zq-18Z" secondAttribute="bottom" constant="12" id="Fcy-ml-yLv"/>
+                                            <constraint firstAttribute="trailing" secondItem="uot-Mo-luY" secondAttribute="trailing" constant="16" id="G6j-th-s3w"/>
+                                            <constraint firstItem="4ni-Mb-siH" firstAttribute="top" secondItem="3Th-tF-r4O" secondAttribute="top" id="J7F-6u-0df"/>
+                                            <constraint firstItem="CKs-Sh-Fpq" firstAttribute="top" secondItem="TJH-VW-Tct" secondAttribute="bottom" constant="20" id="KJK-09-WKi"/>
+                                            <constraint firstItem="t4V-e7-iLN" firstAttribute="leading" secondItem="Ano-jH-ByV" secondAttribute="leading" constant="32" id="Mb7-JA-y5v"/>
+                                            <constraint firstItem="zaJ-zq-18Z" firstAttribute="leading" secondItem="Ano-jH-ByV" secondAttribute="leading" constant="16" id="NQX-ou-gr3"/>
+                                            <constraint firstItem="Vd5-GS-4OI" firstAttribute="leading" secondItem="Ano-jH-ByV" secondAttribute="leading" constant="32" id="RZE-RP-98r"/>
+                                            <constraint firstItem="xwe-Si-O3s" firstAttribute="top" secondItem="Vd5-GS-4OI" secondAttribute="bottom" constant="20" id="S8E-cc-cXq"/>
+                                            <constraint firstItem="uNV-iD-x50" firstAttribute="top" secondItem="t4V-e7-iLN" secondAttribute="bottom" constant="16" id="TDx-wY-Ar3"/>
+                                            <constraint firstItem="uNV-iD-x50" firstAttribute="leading" secondItem="Ano-jH-ByV" secondAttribute="leading" constant="32" id="VRc-kb-eu2"/>
+                                            <constraint firstItem="n7W-To-VFW" firstAttribute="top" secondItem="uot-Mo-luY" secondAttribute="bottom" constant="20" id="YbT-uv-Qx7"/>
+                                            <constraint firstItem="3Th-tF-r4O" firstAttribute="top" secondItem="CKs-Sh-Fpq" secondAttribute="bottom" constant="20" id="Ygn-1s-3sm"/>
+                                            <constraint firstItem="3Th-tF-r4O" firstAttribute="leading" secondItem="Ano-jH-ByV" secondAttribute="leading" constant="16" id="YxT-Sk-ONb"/>
+                                            <constraint firstItem="n7W-To-VFW" firstAttribute="leading" secondItem="hcj-qa-baG" secondAttribute="trailing" constant="20" id="ZgW-yp-Zdl"/>
+                                            <constraint firstItem="s35-8k-0gb" firstAttribute="leading" secondItem="CKs-Sh-Fpq" secondAttribute="trailing" constant="20" id="aQ7-e6-Z8j"/>
+                                            <constraint firstAttribute="trailing" secondItem="3Th-tF-r4O" secondAttribute="trailing" constant="16" id="cws-N9-a9Z"/>
+                                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="s35-8k-0gb" secondAttribute="trailing" constant="16" id="dwe-Pw-L2a"/>
+                                            <constraint firstAttribute="trailing" secondItem="4ni-Mb-siH" secondAttribute="trailing" constant="16" id="ijh-zV-bVq"/>
+                                            <constraint firstItem="hcj-qa-baG" firstAttribute="leading" secondItem="Ano-jH-ByV" secondAttribute="leading" constant="32" id="kxm-Q4-0FF"/>
+                                            <constraint firstAttribute="trailing" secondItem="zaJ-zq-18Z" secondAttribute="trailing" constant="16" id="mu4-Oq-emh"/>
+                                            <constraint firstAttribute="height" priority="250" constant="250" id="n3M-CW-o9L"/>
+                                            <constraint firstItem="Vd5-GS-4OI" firstAttribute="top" secondItem="3Th-tF-r4O" secondAttribute="bottom" constant="20" id="nH6-QY-w4N"/>
+                                            <constraint firstItem="TJH-VW-Tct" firstAttribute="top" secondItem="hcj-qa-baG" secondAttribute="bottom" constant="20" id="paE-a6-tYg"/>
+                                            <constraint firstItem="hcj-qa-baG" firstAttribute="top" secondItem="uot-Mo-luY" secondAttribute="bottom" constant="20" id="qiM-BM-LGV"/>
+                                            <constraint firstItem="3Th-tF-r4O" firstAttribute="top" relation="greaterThanOrEqual" secondItem="s35-8k-0gb" secondAttribute="bottom" constant="4" id="rFC-Va-ZUr"/>
+                                            <constraint firstItem="n7W-To-VFW" firstAttribute="height" secondItem="hcj-qa-baG" secondAttribute="height" id="ujw-UH-GNQ"/>
+                                            <constraint firstAttribute="trailing" secondItem="uNV-iD-x50" secondAttribute="trailing" constant="32" id="vAR-rh-A7q"/>
+                                            <constraint firstItem="4ni-Mb-siH" firstAttribute="leading" secondItem="Vd5-GS-4OI" secondAttribute="trailing" constant="20" id="wq2-yX-sjJ"/>
+                                            <constraint firstItem="TJH-VW-Tct" firstAttribute="top" secondItem="n7W-To-VFW" secondAttribute="bottom" constant="20" id="xdA-fX-BtL"/>
+                                            <constraint firstItem="4ni-Mb-siH" firstAttribute="bottom" secondItem="xwe-Si-O3s" secondAttribute="bottom" id="xme-zm-dwf"/>
+                                            <constraint firstItem="t4V-e7-iLN" firstAttribute="top" secondItem="xwe-Si-O3s" secondAttribute="bottom" constant="20" id="yVm-8n-a2l"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <gestureRecognizers/>
+                                <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="Ano-jH-ByV" secondAttribute="bottom" id="4bV-Cs-2gk"/>
+                                    <constraint firstItem="Ano-jH-ByV" firstAttribute="top" secondItem="teO-Fx-L4D" secondAttribute="top" id="EeS-l6-izR"/>
+                                    <constraint firstItem="Ano-jH-ByV" firstAttribute="centerX" secondItem="teO-Fx-L4D" secondAttribute="centerX" id="i0V-dA-Phz"/>
+                                    <constraint firstItem="Ano-jH-ByV" firstAttribute="width" secondItem="teO-Fx-L4D" secondAttribute="width" id="zTQ-eH-DF4"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="c2I-8I-8DU"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="lgl-1Z-bpW"/>
+                            </scrollView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" name="TestColor"/>
+                        <constraints>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="teO-Fx-L4D" secondAttribute="bottom" id="1ph-KK-yak"/>
+                            <constraint firstItem="teO-Fx-L4D" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="QWK-n6-ahE"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="teO-Fx-L4D" secondAttribute="trailing" id="ljh-LF-Laz"/>
+                            <constraint firstItem="teO-Fx-L4D" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="uJc-me-oRp"/>
+                        </constraints>
                     </view>
+                    <navigationItem key="navigationItem" largeTitleDisplayMode="never" id="Qr8-hB-n59">
+                        <barButtonItem key="leftBarButtonItem" title="취소" id="2uD-ZZ-kGY">
+                            <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" title="완료" id="741-6a-MrW">
+                            <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </barButtonItem>
+                    </navigationItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="11" y="-34"/>
+            <point key="canvasLocation" x="936.64122137404581" y="-34.507042253521128"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="CX7-OJ-5BG">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="45C-kJ-km3" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" translucent="NO" id="UG2-H3-DhO">
+                        <rect key="frame" x="0.0" y="59" width="393" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <color key="backgroundColor" red="0.34901960780000002" green="0.36862745099999999" blue="0.47058823529999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="barTintColor" red="0.34901960784313724" green="0.36862745098039218" blue="0.47058823529411764" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <textAttributes key="titleTextAttributes">
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </textAttributes>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="0eK-ZC-jmm">
+                        <autoresizingMask key="autoresizingMask"/>
+                    </toolbar>
+                    <connections>
+                        <segue destination="Y6W-OH-hqX" kind="relationship" relationship="rootViewController" id="wKK-we-pYK"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ybb-NE-dw4" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="9.9236641221374047" y="-34.507042253521128"/>
         </scene>
     </scenes>
     <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
+        <image name="chevron.right" catalog="system" width="97" height="128"/>
+        <namedColor name="TestColor">
+            <color red="0.34901960784313724" green="0.36862745098039218" blue="0.47058823529411764" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
     </resources>
 </document>

--- a/GetARock/GetARock/Global/Resource/Storyboards/AddGathering.storyboard
+++ b/GetARock/GetARock/Global/Resource/Storyboards/AddGathering.storyboard
@@ -17,7 +17,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="749"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="teO-Fx-L4D">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="teO-Fx-L4D">
                                 <rect key="frame" x="0.0" y="0.0" width="393" height="715"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ano-jH-ByV" userLabel="scrollContentView">
@@ -63,6 +63,15 @@
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
+                                            <datePicker contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="249" contentHorizontalAlignment="leading" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="s35-8k-0gb">
+                                                <rect key="frame" x="82.000000000000014" y="153" width="217.33333333333337" height="34.333333333333343"/>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" priority="250" constant="200" id="e3c-J5-JwX"/>
+                                                </constraints>
+                                                <locale key="locale" localeIdentifier="ko_KR"/>
+                                            </datePicker>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3Th-tF-r4O" userLabel="SeparatorView">
                                                 <rect key="frame" x="16" y="200.33333333333331" width="361" height="1"/>
                                                 <color key="backgroundColor" red="0.52941176469999995" green="0.5568627451" blue="0.68235294120000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -119,21 +128,12 @@
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
-                                            <datePicker contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="249" contentHorizontalAlignment="leading" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="s35-8k-0gb">
-                                                <rect key="frame" x="82" y="153" width="215" height="34.333333333333343"/>
-                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" priority="250" constant="200" id="e3c-J5-JwX"/>
-                                                </constraints>
-                                                <locale key="locale" localeIdentifier="ko_KR"/>
-                                            </datePicker>
                                         </subviews>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstItem="zaJ-zq-18Z" firstAttribute="top" secondItem="Ano-jH-ByV" secondAttribute="top" constant="40" id="2Ix-uj-Vg3"/>
                                             <constraint firstAttribute="trailing" secondItem="xwe-Si-O3s" secondAttribute="trailing" constant="13" id="2So-G0-7QC"/>
-                                            <constraint firstItem="s35-8k-0gb" firstAttribute="top" relation="greaterThanOrEqual" secondItem="TJH-VW-Tct" secondAttribute="bottom" constant="4" id="3YF-T5-1Re"/>
+                                            <constraint firstItem="s35-8k-0gb" firstAttribute="top" relation="lessThanOrEqual" secondItem="TJH-VW-Tct" secondAttribute="bottom" constant="20" id="3YF-T5-1Re"/>
                                             <constraint firstAttribute="trailing" secondItem="TJH-VW-Tct" secondAttribute="trailing" constant="16" id="4Cu-4C-ewo"/>
                                             <constraint firstAttribute="bottom" secondItem="uNV-iD-x50" secondAttribute="bottom" id="9Cx-dS-ahM"/>
                                             <constraint firstItem="CKs-Sh-Fpq" firstAttribute="leading" secondItem="Ano-jH-ByV" secondAttribute="leading" constant="32" id="C04-yD-GWx"/>
@@ -150,6 +150,7 @@
                                             <constraint firstItem="Vd5-GS-4OI" firstAttribute="leading" secondItem="Ano-jH-ByV" secondAttribute="leading" constant="32" id="RZE-RP-98r"/>
                                             <constraint firstItem="xwe-Si-O3s" firstAttribute="top" secondItem="Vd5-GS-4OI" secondAttribute="bottom" constant="20" id="S8E-cc-cXq"/>
                                             <constraint firstItem="uNV-iD-x50" firstAttribute="top" secondItem="t4V-e7-iLN" secondAttribute="bottom" constant="16" id="TDx-wY-Ar3"/>
+                                            <constraint firstItem="s35-8k-0gb" firstAttribute="top" relation="greaterThanOrEqual" secondItem="TJH-VW-Tct" secondAttribute="bottom" constant="4" id="TlP-R3-wPO"/>
                                             <constraint firstItem="uNV-iD-x50" firstAttribute="leading" secondItem="Ano-jH-ByV" secondAttribute="leading" constant="32" id="VRc-kb-eu2"/>
                                             <constraint firstItem="n7W-To-VFW" firstAttribute="top" secondItem="uot-Mo-luY" secondAttribute="bottom" constant="20" id="YbT-uv-Qx7"/>
                                             <constraint firstItem="3Th-tF-r4O" firstAttribute="top" secondItem="CKs-Sh-Fpq" secondAttribute="bottom" constant="20" id="Ygn-1s-3sm"/>
@@ -163,9 +164,10 @@
                                             <constraint firstAttribute="trailing" secondItem="zaJ-zq-18Z" secondAttribute="trailing" constant="16" id="mu4-Oq-emh"/>
                                             <constraint firstAttribute="height" priority="250" constant="250" id="n3M-CW-o9L"/>
                                             <constraint firstItem="Vd5-GS-4OI" firstAttribute="top" secondItem="3Th-tF-r4O" secondAttribute="bottom" constant="20" id="nH6-QY-w4N"/>
+                                            <constraint firstItem="3Th-tF-r4O" firstAttribute="top" relation="greaterThanOrEqual" secondItem="s35-8k-0gb" secondAttribute="bottom" constant="4" id="ok4-6P-Ty1"/>
                                             <constraint firstItem="TJH-VW-Tct" firstAttribute="top" secondItem="hcj-qa-baG" secondAttribute="bottom" constant="20" id="paE-a6-tYg"/>
                                             <constraint firstItem="hcj-qa-baG" firstAttribute="top" secondItem="uot-Mo-luY" secondAttribute="bottom" constant="20" id="qiM-BM-LGV"/>
-                                            <constraint firstItem="3Th-tF-r4O" firstAttribute="top" relation="greaterThanOrEqual" secondItem="s35-8k-0gb" secondAttribute="bottom" constant="4" id="rFC-Va-ZUr"/>
+                                            <constraint firstItem="3Th-tF-r4O" firstAttribute="top" relation="lessThanOrEqual" secondItem="s35-8k-0gb" secondAttribute="bottom" constant="20" id="rFC-Va-ZUr"/>
                                             <constraint firstItem="n7W-To-VFW" firstAttribute="height" secondItem="hcj-qa-baG" secondAttribute="height" id="ujw-UH-GNQ"/>
                                             <constraint firstAttribute="trailing" secondItem="uNV-iD-x50" secondAttribute="trailing" constant="32" id="vAR-rh-A7q"/>
                                             <constraint firstItem="4ni-Mb-siH" firstAttribute="leading" secondItem="Vd5-GS-4OI" secondAttribute="trailing" constant="20" id="wq2-yX-sjJ"/>
@@ -178,10 +180,12 @@
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <gestureRecognizers/>
                                 <constraints>
-                                    <constraint firstAttribute="bottom" secondItem="Ano-jH-ByV" secondAttribute="bottom" id="4bV-Cs-2gk"/>
-                                    <constraint firstItem="Ano-jH-ByV" firstAttribute="top" secondItem="teO-Fx-L4D" secondAttribute="top" id="EeS-l6-izR"/>
-                                    <constraint firstItem="Ano-jH-ByV" firstAttribute="centerX" secondItem="teO-Fx-L4D" secondAttribute="centerX" id="i0V-dA-Phz"/>
-                                    <constraint firstItem="Ano-jH-ByV" firstAttribute="width" secondItem="teO-Fx-L4D" secondAttribute="width" id="zTQ-eH-DF4"/>
+                                    <constraint firstItem="Ano-jH-ByV" firstAttribute="top" secondItem="c2I-8I-8DU" secondAttribute="top" id="0L6-qP-L86"/>
+                                    <constraint firstItem="Ano-jH-ByV" firstAttribute="leading" secondItem="lgl-1Z-bpW" secondAttribute="leading" id="6rP-mk-DAN"/>
+                                    <constraint firstItem="lgl-1Z-bpW" firstAttribute="trailing" secondItem="Ano-jH-ByV" secondAttribute="trailing" id="MMj-eU-u5h"/>
+                                    <constraint firstItem="Ano-jH-ByV" firstAttribute="width" secondItem="c2I-8I-8DU" secondAttribute="width" id="fcn-bV-eCU"/>
+                                    <constraint firstItem="Ano-jH-ByV" firstAttribute="bottom" secondItem="c2I-8I-8DU" secondAttribute="bottom" id="fec-tb-wyQ"/>
+                                    <constraint firstItem="Ano-jH-ByV" firstAttribute="centerX" secondItem="c2I-8I-8DU" secondAttribute="centerX" id="qPG-mz-hFu"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="c2I-8I-8DU"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="lgl-1Z-bpW"/>

--- a/GetARock/GetARock/Global/Resource/Storyboards/AddGathering.storyboard
+++ b/GetARock/GetARock/Global/Resource/Storyboards/AddGathering.storyboard
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Add Gathering View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController id="Y6W-OH-hqX" customClass="AddGatheringViewController" customModule="GetARock" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="11" y="-34"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
+++ b/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
@@ -1,0 +1,17 @@
+//
+//  AddGatheringViewController.swift
+//  GetARock
+//
+//  Created by Hyorim Nam on 2022/11/21.
+//
+
+import UIKit
+
+class AddGatheringViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈
#36 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 배경
모여락(밴드 이벤트)를 만들 때 유저가 정보를 입력하는 화면을 구현합니다. 
<!-- PR과 관련된 논의 쓰레드, 디자인 가이드, 관련 PR 링크 등을 적어주세요 -->

## 작업 내용
스토리보드만 사용했습니다.  
스토리보드의 라인 수가 많아 텍스트뷰의 플레이스홀더처럼 코드를 쓰는 것은 PR을 분리합니다. 
1. 네비게이션 컨트롤은 모여락 위치 선택 뷰로의 연결을 위해 먼저 추가했습니다.
2. 화면은 밴드소개가 길어질 것을 대비해 스크롤뷰를 사용했습니다. 
  - 키보드 영역까지 하면 스크롤뷰가 필요할 것 같습니다.
3. 각각의 항목은 오토레이아웃으로 했습니다. 
  (스택뷰는 주최 등 입력항목 이름의 위치나 데이트피커의 길이를 다루기 어렵고 이 경우에는 변경 라인수가 더 길었습니다)
5. 색과 폰트는 장소와 저장 기능 구현 후 고치려고 합니다. 
<img width="594" alt="image" src="https://user-images.githubusercontent.com/18394923/202972744-51365886-4197-4f29-bdd0-9edb959e659a.png">

<!-- PR 작성 이유와 어떤 변경이 있었는지를 포함합니다. PR에 많은 변경이 있는 경우 추가되는 클래스들의 구조나 동작 등 자세하게 적는 경우도 있습니다 -->

## 테스트 방법
모달로 쓸 뷰라서 다른 뷰에서 연결해서 보면 좋습니다. 
테스트 시작용 스토리보드를 따로 만들어두고, 스토리보드 레퍼런스로 연결하면 편합니다. 
<!-- PR 리뷰어가 이 PR의 변경사항을 확인할 수 있는 방법을 서술합니다. 의도하는 테스트 결과도 서술하면 더 좋습니다 -->

## 리뷰 노트
- 텍스트뷰 플레이스홀더, 위치 선택 뷰 연결과 키보드 관련 일부 설정은 다음 PR로 넘깁니다. 
- PR 사이즈와 관련해서 스토리보드의 코드 줄 수를 생각하는 게 어렵네요. 노하우 있으신 분 알려주시면 감사합니다. 
<!-- 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술합니다. 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트를 요청하는 경우에 작성합니다. -->

## 스크린샷
피그마 | 스크린샷 |
:----: | :----: |
<img width="300" alt="" src="https://user-images.githubusercontent.com/18394923/202927621-566dc7fb-0c88-4687-b84d-d2634918a0fb.png"> | <img width="300" alt="" src="https://user-images.githubusercontent.com/18394923/202970605-c85518d7-d51c-416c-92b2-b98e54675613.png"> |


<!-- 화면 전환이나 인터랙션이 있는 경우 GIF를, 정적인 화면이라면 스크린샷을 첨부합니다. -->
<!-- <img width="" alt="" src=""> -->
