### PR TITLE
[Refactor] UIColor extension 코드 수정 #67

### DIFF
--- a/GetARock/GetARock/Global/Extension/UIColor+Extension.swift
+++ b/GetARock/GetARock/Global/Extension/UIColor+Extension.swift
@@ -7,19 +7,55 @@
 
 import UIKit
 
-enum AppColor {
-    case mainPurple
-    case lightPurple
-    case mainBlue
-    case gradationBlue
-    case subBlue
-    case lightBlue
-    case dividerBlue
-    case backgroundBlue
-    case modalBackgroundBlue
-    case lightGrey
-    case backgroundWhite
-    case warningRed
+extension UIColor {
+
+    static var mainPurple: UIColor {
+        return #colorLiteral(red: 0.6862745098, green: 0.3019607843, blue: 0.9254901961, alpha: 1)
+    }
+
+    static var lightPurple: UIColor {
+        return #colorLiteral(red: 0.9254901961, green: 0.8039215686, blue: 1, alpha: 1)
+    }
+
+    static var mainBlue: UIColor {
+        return #colorLiteral(red: 0.4941176471, green: 0.5254901961, blue: 0.6862745098, alpha: 1)
+    }
+
+    static var gradationBlue: UIColor {
+        return #colorLiteral(red: 0.4274509804, green: 0.4941176471, blue: 0.968627451, alpha: 1)
+    }
+
+    static var subBlue: UIColor {
+        return #colorLiteral(red: 0.4823529412, green: 0.9019607843, blue: 0.9333333333, alpha: 1)
+    }
+
+    static var lightBlue: UIColor {
+        return #colorLiteral(red: 0.6470588235, green: 0.7019607843, blue: 1, alpha: 1)
+    }
+
+    static var dividerBlue: UIColor {
+        return #colorLiteral(red: 0.5294117647, green: 0.5568627451, blue: 0.6823529412, alpha: 1)
+    }
+
+    static var backgroundBlue: UIColor {
+        return #colorLiteral(red: 0.4039215686, green: 0.4274509804, blue: 0.5411764706, alpha: 1)
+    }
+
+    static var modalBackgroundBlue: UIColor {
+        return #colorLiteral(red: 0.3490196078, green: 0.368627451, blue: 0.4705882353, alpha: 1)
+    }
+
+    static var lightGrey: UIColor {
+        return #colorLiteral(red: 0.7843137255, green: 0.7843137255, blue: 0.7843137255, alpha: 1)
+    }
+
+    static var backgroundWhite: UIColor {
+        return #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0.2)
+    }
+
+    static var warningRed: UIColor {
+        return #colorLiteral(red: 0.7921568627, green: 0, blue: 0, alpha: 1)
+    }
 }
 
 extension UIColor {
@@ -31,45 +67,5 @@ extension UIColor {
             blue: CGFloat(blue) / 255.0,
             alpha: CGFloat(alpha) / 255.0
         )
-    }
-    
-    static func appColor(_ name: AppColor) -> UIColor {
-        switch name {
-        case .mainPurple:
-            return #colorLiteral(red: 0.6862745098, green: 0.3019607843, blue: 0.9254901961, alpha: 1)
-            
-        case .lightPurple:
-            return #colorLiteral(red: 0.9254901961, green: 0.8039215686, blue: 1, alpha: 1)
-            
-        case .mainBlue:
-            return #colorLiteral(red: 0.4941176471, green: 0.5254901961, blue: 0.6862745098, alpha: 1)
-            
-        case .gradationBlue:
-            return #colorLiteral(red: 0.4274509804, green: 0.4941176471, blue: 0.968627451, alpha: 1)
-            
-        case .subBlue:
-            return #colorLiteral(red: 0.4823529412, green: 0.9019607843, blue: 0.9333333333, alpha: 1)
-            
-        case .lightBlue:
-            return #colorLiteral(red: 0.6470588235, green: 0.7019607843, blue: 1, alpha: 1)
-            
-        case .dividerBlue:
-            return #colorLiteral(red: 0.5294117647, green: 0.5568627451, blue: 0.6823529412, alpha: 1)
-            
-        case .backgroundBlue:
-            return #colorLiteral(red: 0.4039215686, green: 0.4274509804, blue: 0.5411764706, alpha: 1)
-            
-        case .modalBackgroundBlue:
-            return #colorLiteral(red: 0.3490196078, green: 0.368627451, blue: 0.4705882353, alpha: 1)
-            
-        case .lightGrey:
-            return #colorLiteral(red: 0.7843137255, green: 0.7843137255, blue: 0.7843137255, alpha: 1)
-            
-        case .backgroundWhite:
-            return #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0.2)
-            
-        case .warningRed:
-            return #colorLiteral(red: 0.7921568627, green: 0, blue: 0, alpha: 1)
-        }
     }
 }

--- a/GetARock/GetARock/Global/Utils/UIView+Gradation.swift
+++ b/GetARock/GetARock/Global/Utils/UIView+Gradation.swift
@@ -16,13 +16,13 @@ extension UIView {
         gradient.endPoint = CGPoint(x: 1.0, y: endPointY)
         gradient.locations = [0.0, 1.0]
         gradient.frame = self.bounds
-        self.layer.insertSublayer(gradient, at: 0)
+        self.layer.addSublayer(gradient)
     }
 
     func fillMainGradient() {
         setGradient(
-            startColor: UIColor.appColor(.mainPurple),
-            endColor: UIColor.appColor(.gradationBlue),
+            startColor: .mainPurple,
+            endColor: .gradationBlue,
             startPointY: 0.5,
             endPointY: 0.5
         )
@@ -30,7 +30,7 @@ extension UIView {
 
     func fillActiveGradation() {
         setGradient(
-            startColor: UIColor.appColor(.mainPurple).withAlphaComponent(0.3),
+            startColor: UIColor.mainPurple.withAlphaComponent(0.3),
             endColor: UIColor.black.withAlphaComponent(0.0),
             startPointY: 0.0,
             endPointY: 1.0


### PR DESCRIPTION

## 관련 이슈

#67 

## 배경

어제 스누피의 조언을 바탕으로 더 효율적인 코드로 Refactor 하기 위해 수정을 진행합니다.

- #43 
- PR을 보시면 아시겠지만 색을 정의할때 `eunm`과 `switch문`을 사용해서 코드 작성
   - 열거형을 사용한 이유 : 가독성 ⬆︎ / 안정성 ⬆︎ / Enum은  Stack에 저장, 고로 성능면에서도 향상
  
### CTO 스누피🐶의 조언
   -  eunm을 사용해서 구현 시, 색상을 사용 할때마다 새로운 컬러를 만들어서 메모리 사용이 더 안 좋음
   -  BUT, `static var`를 사용해서 저장 시, 이미 저장된 값에서 가져오기 때문에 더 효율이 좋음!

(저도 바쁜거끝나면 관련 자료찾아서 추가하겠습당..!)

## 작업 내용
UIColor extension에서 각 색상을 정의하던 방식 변경
- enum과 switch문을 사용하던 형식에서 전역변수로 변경


## 테스트 방법
이제 원하는 색상을 사용하고 싶을때 .(점) 찍고 바로 사용하세유!
```
view.backgroundColor = .mainPurple
```