### PR TITLE
[Feat] 모여락(밴드 이벤트) 추가 화면의 인터랙션(텍스트필드, 텍스트뷰, 화면 이동)을 설정합니다. 

### DIFF
--- a/GetARock/GetARock/Global/Resource/Storyboards/AddGathering.storyboard
+++ b/GetARock/GetARock/Global/Resource/Storyboards/AddGathering.storyboard
@@ -6,6 +6,7 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -100,12 +101,16 @@
                                                     </imageView>
                                                 </subviews>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <gestureRecognizers/>
                                                 <constraints>
                                                     <constraint firstItem="cyd-eb-cyK" firstAttribute="leading" secondItem="4ni-Mb-siH" secondAttribute="leading" id="EVS-14-Rbg"/>
                                                     <constraint firstItem="KTx-Vq-Mud" firstAttribute="centerY" secondItem="4ni-Mb-siH" secondAttribute="centerY" id="Od3-a9-f1l"/>
                                                     <constraint firstItem="cyd-eb-cyK" firstAttribute="centerY" secondItem="4ni-Mb-siH" secondAttribute="centerY" id="S2l-4q-XkU"/>
                                                     <constraint firstAttribute="trailing" secondItem="KTx-Vq-Mud" secondAttribute="trailing" id="kEj-TP-4OS"/>
                                                 </constraints>
+                                                <connections>
+                                                    <outletCollection property="gestureRecognizers" destination="Cif-I3-r5A" appends="YES" id="yVD-bN-hNw"/>
+                                                </connections>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xwe-Si-O3s" userLabel="SeparatorView">
                                                 <rect key="frame" x="19" y="261.66666666666669" width="361" height="1"/>
@@ -210,15 +215,36 @@
                     </navigationItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <tapGestureRecognizer id="Cif-I3-r5A" userLabel="locationSelectTapRecognizer">
+                    <connections>
+                        <segue destination="JXE-kZ-dOE" kind="show" id="9DQ-Is-Tll"/>
+                    </connections>
+                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="936.64122137404581" y="-34.507042253521128"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="tZe-x4-f5c">
+            <objects>
+                <viewController id="JXE-kZ-dOE" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="XwN-hz-0Db">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="749"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="XZi-Sq-Q9v"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="heY-lu-3aH"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="1ZL-bc-2KO" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1705" y="-35"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="CX7-OJ-5BG">
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="45C-kJ-km3" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" translucent="NO" id="UG2-H3-DhO">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" translucent="NO" backIndicatorImage="chevron.left" catalog="system" id="UG2-H3-DhO">
                         <rect key="frame" x="0.0" y="59" width="393" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" red="0.34901960780000002" green="0.36862745099999999" blue="0.47058823529999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -242,9 +268,13 @@
         </scene>
     </scenes>
     <resources>
+        <image name="chevron.left" catalog="system" width="97" height="128"/>
         <image name="chevron.right" catalog="system" width="97" height="128"/>
         <namedColor name="TestColor">
             <color red="0.34901960784313724" green="0.36862745098039218" blue="0.47058823529411764" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/GetARock/GetARock/Global/Resource/Storyboards/AddGathering.storyboard
+++ b/GetARock/GetARock/Global/Resource/Storyboards/AddGathering.storyboard
@@ -213,6 +213,11 @@
                             <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </barButtonItem>
                     </navigationItem>
+                    <connections>
+                        <outlet property="aboutTextView" destination="uNV-iD-x50" id="hNT-BR-jA8"/>
+                        <outlet property="hostBandNameLabel" destination="n7W-To-VFW" id="RSA-Hm-SvS"/>
+                        <outlet property="titleTextField" destination="zaJ-zq-18Z" id="Al4-Ik-WXX"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
                 <tapGestureRecognizer id="Cif-I3-r5A" userLabel="locationSelectTapRecognizer">

--- a/GetARock/GetARock/Global/Resource/Storyboards/AddGathering.storyboard
+++ b/GetARock/GetARock/Global/Resource/Storyboards/AddGathering.storyboard
@@ -65,7 +65,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <datePicker contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="249" contentHorizontalAlignment="leading" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="s35-8k-0gb">
-                                                <rect key="frame" x="82.000000000000014" y="153" width="217.33333333333337" height="34.333333333333343"/>
+                                                <rect key="frame" x="82" y="153" width="228" height="34.333333333333343"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
@@ -125,7 +125,7 @@
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="uNV-iD-x50">
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="uNV-iD-x50" userLabel="Introduction Text View">
                                                 <rect key="frame" x="32" y="319" width="329" height="33"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <color key="tintColor" red="0.5647059083" green="0.58039218189999997" blue="0.68235301969999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
@@ -220,8 +220,8 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
-                        <outlet property="aboutTextView" destination="uNV-iD-x50" id="qel-ZL-s05"/>
                         <outlet property="hostBandNameLabel" destination="n7W-To-VFW" id="RSA-Hm-SvS"/>
+                        <outlet property="introductionTextView" destination="uNV-iD-x50" id="NuI-MW-yqf"/>
                         <outlet property="scrollView" destination="teO-Fx-L4D" id="Pwm-8O-BPx"/>
                         <outlet property="titleTextField" destination="zaJ-zq-18Z" id="Al4-Ik-WXX"/>
                     </connections>

--- a/GetARock/GetARock/Global/Resource/Storyboards/AddGathering.storyboard
+++ b/GetARock/GetARock/Global/Resource/Storyboards/AddGathering.storyboard
@@ -194,6 +194,9 @@
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="c2I-8I-8DU"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="lgl-1Z-bpW"/>
+                                <connections>
+                                    <outletCollection property="gestureRecognizers" destination="l4z-MO-Q2z" appends="YES" id="dn4-Cq-03H"/>
+                                </connections>
                             </scrollView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
@@ -214,8 +217,9 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
-                        <outlet property="aboutTextView" destination="uNV-iD-x50" id="hNT-BR-jA8"/>
+                        <outlet property="aboutTextView" destination="uNV-iD-x50" id="qel-ZL-s05"/>
                         <outlet property="hostBandNameLabel" destination="n7W-To-VFW" id="RSA-Hm-SvS"/>
+                        <outlet property="scrollView" destination="teO-Fx-L4D" id="Pwm-8O-BPx"/>
                         <outlet property="titleTextField" destination="zaJ-zq-18Z" id="Al4-Ik-WXX"/>
                     </connections>
                 </viewController>
@@ -223,6 +227,11 @@
                 <tapGestureRecognizer id="Cif-I3-r5A" userLabel="locationSelectTapRecognizer">
                     <connections>
                         <segue destination="JXE-kZ-dOE" kind="show" id="9DQ-Is-Tll"/>
+                    </connections>
+                </tapGestureRecognizer>
+                <tapGestureRecognizer id="l4z-MO-Q2z" userLabel="scrollViewTapRecognizer">
+                    <connections>
+                        <action selector="scrollViewTapRecognizer:" destination="Y6W-OH-hqX" id="MlT-sy-UGr"/>
                     </connections>
                 </tapGestureRecognizer>
             </objects>

--- a/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
+++ b/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
@@ -9,9 +9,17 @@ import UIKit
 
 class AddGatheringViewController: UIViewController {
 
+    // MARK: - Life Cycle
+
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
+        setupNavigationBar()
     }
 
+    // MARK: - Method
+
+    private func setupNavigationBar() {
+        navigationController?.navigationBar.shadowImage = UIImage()
+    }
 }

--- a/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
+++ b/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
@@ -13,7 +13,7 @@ class AddGatheringViewController: UIViewController {
 
     @IBOutlet weak var titleTextField: UITextField!
     @IBOutlet weak var hostBandNameLabel: UILabel!
-    @IBOutlet weak var aboutTextView: UITextView!
+    @IBOutlet weak var introductionTextView: UITextView!
     @IBOutlet weak var scrollView: UIScrollView!
 
     private let placeHolderLabel: UILabel = {
@@ -30,6 +30,7 @@ class AddGatheringViewController: UIViewController {
         super.viewDidLoad()
         
         attribute()
+        setDelegate()
         setupLayout()
     }
 
@@ -40,15 +41,19 @@ class AddGatheringViewController: UIViewController {
     }
 
     @IBAction func scrollViewTapRecognizer(_ sender: UITapGestureRecognizer) {
-        titleTextField.endEditing(true)
-        aboutTextView.endEditing(true)
+        view.endEditing(true)
     }
 
     private func attribute() {
         setupNavigationBar()
         hostBandNameLabel.text = "블랙로즈" // 추후 유저디폴트 사용 예정
         titleTextField.becomeFirstResponder()
+        introductionTextView.delegate = self
         getKeyboardNotification()
+    }
+
+    private func setDelegate() {
+        introductionTextView.delegate = self
     }
 
     private func setupNavigationBar() {
@@ -59,10 +64,9 @@ class AddGatheringViewController: UIViewController {
         view.addSubview(placeHolderLabel)
         placeHolderLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            placeHolderLabel.topAnchor.constraint(equalTo: aboutTextView.topAnchor, constant: 8),
-            placeHolderLabel.leadingAnchor.constraint(equalTo: aboutTextView.leadingAnchor, constant: 4)
+            placeHolderLabel.topAnchor.constraint(equalTo: introductionTextView.topAnchor, constant: 8),
+            placeHolderLabel.leadingAnchor.constraint(equalTo: introductionTextView.leadingAnchor, constant: 4)
         ])
-        aboutTextView.delegate = self
     }
 }
 
@@ -70,11 +74,11 @@ class AddGatheringViewController: UIViewController {
 
 extension AddGatheringViewController: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
-        self.placeHolderLabel.textColor = aboutTextView.text.count == 0 ? .lightGray : .clear
+        self.placeHolderLabel.textColor = introductionTextView.text.count == 0 ? .lightGray : .clear
     }
 }
 
-// MARK: - KeyboardNotification
+// MARK: - KeyboardControl
 
 extension AddGatheringViewController {
     private func getKeyboardNotification() {
@@ -84,7 +88,7 @@ extension AddGatheringViewController {
 
     @objc func keyboardWillShow(_ sender: Notification) {
         guard let userInfo: NSDictionary = sender.userInfo as NSDictionary?,
-              let keyboardFrame: NSValue = userInfo.value(forKey: UIResponder.keyboardFrameEndUserInfoKey) as? NSValue else{
+              let keyboardFrame: NSValue = userInfo.value(forKey: UIResponder.keyboardFrameEndUserInfoKey) as? NSValue else {
                   return
               }
         let keyboardRectangle = keyboardFrame.cgRectValue

--- a/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
+++ b/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
@@ -14,6 +14,7 @@ class AddGatheringViewController: UIViewController {
     @IBOutlet weak var titleTextField: UITextField!
     @IBOutlet weak var hostBandNameLabel: UILabel!
     @IBOutlet weak var aboutTextView: UITextView!
+    @IBOutlet weak var scrollView: UIScrollView!
 
     private let placeHolderLabel: UILabel = {
         $0.text = "내용을 입력하세요"
@@ -33,6 +34,11 @@ class AddGatheringViewController: UIViewController {
     }
 
     // MARK: - Method
+
+    @IBAction func scrollViewTapRecognizer(_ sender: UITapGestureRecognizer) {
+        titleTextField.endEditing(true)
+        aboutTextView.endEditing(true)
+    }
 
     private func attribute() {
         setupNavigationBar()

--- a/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
+++ b/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
@@ -34,6 +34,11 @@ class AddGatheringViewController: UIViewController {
         setupLayout()
     }
 
+    deinit {
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+
     // MARK: - Method
 
     @IBAction func cancelButtonAction(_ sender: UIBarButtonItem) {

--- a/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
+++ b/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
@@ -9,17 +9,54 @@ import UIKit
 
 class AddGatheringViewController: UIViewController {
 
+    // MARK: - View
+
+    @IBOutlet weak var titleTextField: UITextField!
+    @IBOutlet weak var hostBandNameLabel: UILabel!
+    @IBOutlet weak var aboutTextView: UITextView!
+
+    private let placeHolderLabel: UILabel = {
+        $0.text = "내용을 입력하세요"
+        $0.textColor = .lightGray
+        $0.sizeToFit()
+        $0.font = .preferredFont(forTextStyle: .subheadline)
+        return $0
+    }(UILabel())
+
     // MARK: - Life Cycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setupNavigationBar()
+        attribute()
+        setupLayout()
     }
 
     // MARK: - Method
 
+    private func attribute() {
+        setupNavigationBar()
+    }
+
     private func setupNavigationBar() {
         navigationController?.navigationBar.shadowImage = UIImage()
+    }
+
+    private func setupLayout() {
+        view.addSubview(placeHolderLabel)
+        placeHolderLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            placeHolderLabel.topAnchor.constraint(equalTo: aboutTextView.topAnchor, constant: 8),
+            placeHolderLabel.leadingAnchor.constraint(equalTo: aboutTextView.leadingAnchor, constant: 4)
+        ])
+        aboutTextView.delegate = self
+    }
+}
+
+// MARK: - UITextViewDelegate
+
+extension AddGatheringViewController: UITextViewDelegate {
+    func textViewDidChange(_ textView: UITextView) {
+        self.placeHolderLabel.textColor = aboutTextView.text.count == 0 ? .lightGray : .clear
     }
 }

--- a/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
+++ b/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
@@ -48,7 +48,6 @@ class AddGatheringViewController: UIViewController {
         setupNavigationBar()
         hostBandNameLabel.text = "블랙로즈" // 추후 유저디폴트 사용 예정
         titleTextField.becomeFirstResponder()
-        introductionTextView.delegate = self
         getKeyboardNotification()
     }
 

--- a/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
+++ b/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
@@ -44,6 +44,7 @@ class AddGatheringViewController: UIViewController {
         setupNavigationBar()
         hostBandNameLabel.text = "블랙로즈" // 추후 유저디폴트 사용 예정
         titleTextField.becomeFirstResponder()
+        getKeyboardNotification()
     }
 
     private func setupNavigationBar() {
@@ -66,5 +67,41 @@ class AddGatheringViewController: UIViewController {
 extension AddGatheringViewController: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
         self.placeHolderLabel.textColor = aboutTextView.text.count == 0 ? .lightGray : .clear
+    }
+}
+
+// MARK: - KeyboardNotification
+
+extension AddGatheringViewController {
+    private func getKeyboardNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+
+    @objc func keyboardWillShow(_ sender: Notification) {
+        guard let userInfo: NSDictionary = sender.userInfo as NSDictionary?,
+              let keyboardFrame: NSValue = userInfo.value(forKey: UIResponder.keyboardFrameEndUserInfoKey) as? NSValue else{
+                  return
+              }
+        let keyboardRectangle = keyboardFrame.cgRectValue
+        let keyboardHeight = keyboardRectangle.height
+
+        let contentInset = UIEdgeInsets(
+            top: 0.0,
+            left: 0.0,
+            bottom: keyboardHeight,
+            right: 0.0)
+        scrollView.contentInset = contentInset
+        scrollView.scrollIndicatorInsets = contentInset
+    }
+
+    @objc func keyboardWillHide(_ sender: Notification) {
+        let contentInset = UIEdgeInsets(
+                top: 0.0,
+                left: 0.0,
+                bottom: 0.0,
+                right: 0.0)
+            scrollView.contentInset = contentInset
+            scrollView.scrollIndicatorInsets = contentInset
     }
 }

--- a/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
+++ b/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
@@ -36,6 +36,8 @@ class AddGatheringViewController: UIViewController {
 
     private func attribute() {
         setupNavigationBar()
+        hostBandNameLabel.text = "블랙로즈" // 추후 유저디폴트 사용 예정
+        titleTextField.becomeFirstResponder()
     }
 
     private func setupNavigationBar() {


### PR DESCRIPTION
## 관련 이슈
close #36
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 배경
모여락(밴드 이벤트) 추가 화면이 작동하도록 합니다. 
위치 설정 뷰와 데이터 저장은 다른 이슈에서 다룹니다. 

추가로 저번 PR #61  을 수정하다가 놓친 네비게이션 바 아래의 선을 보이지 않도록 했습니다. 
<!-- PR과 관련된 논의 쓰레드, 디자인 가이드, 관련 PR 링크 등을 적어주세요 -->

## 작업 내용
텍스트필드
- [x] 텍스트필드가 뷰를 열었을 때 바로 선택되어 있도록 설정

텍스트뷰 관련
  - [x] 텍스트뷰의 플레이스홀더 설정
  - [x] 키보드가 아래에서 올라올 때 스크롤뷰도 그만큼 올라가도록 설정
  - [x] 키보드 외의 스크롤뷰 내부가 탭되었을 때 키보드가 내려가도록 설정

화면 이동
  - [x] 위치 설정 영역을 탭하면 새 뷰컨트롤러로 이동하도록 설정
  - [x] 취소 버튼을 누르면 (present된) 뷰가 사라지도록 설정 

기타
  - [x] 네비게이션 바 아래의 선이 보이지 않도록 수정 
<!-- PR 작성 이유와 어떤 변경이 있었는지를 포함합니다. PR에 많은 변경이 있는 경우 추가되는 클래스들의 구조나 동작 등 자세하게 적는 경우도 있습니다 -->

## 테스트 방법
Landing.storyboard에 storyboard reference로 AddGathering.storyboard를 추가하고 버튼을 누르면 show나 present modally로 연결합니다.
<!-- PR 리뷰어가 이 PR의 변경사항을 확인할 수 있는 방법을 서술합니다. 의도하는 테스트 결과도 서술하면 더 좋습니다 -->

## 리뷰 노트
- [키보드 관련] 키보드가 아래에서 올라올 때 스크롤뷰도 그만큼 올라가도록 하는 방법
  - 스크롤뷰의 아래에 키보드 크기만큼 EdgeInset을 변경해 동적으로 패딩을 줍니다. 
    - 키보드의 크기는 키보드가 올라올 때 NotificationCenter로 받습니다. 
  - 스크롤뷰 아래에 패딩이 생기기 때문에 스크롤뷰도 기대한 곳에 위치합니다. 
    - [참고 블로그](https://seizze.github.io/2019/11/17/iOS에서-키보드에-동적인-스크롤뷰-만들기.html), [관련 디스커션](https://github.com/DeveloperAcademy-POSTECH/MacC-GetARock/discussions/62#discussion-4585381)

- [실행시 로그] 가 찍히는데, 검색해보니 Xcode 업데이트되면서 생겼고, 해결할 문제가 아니라는 것 같아 무시했습니다. 
  - 참고 페이지: [애플 개발자 포럼](https://developer.apple.com/forums/thread/714278), [스택오버플로](https://stackoverflow.com/a/74447543/6183323)
  - 로그 내용: `[Assert] UINavigationBar decoded as unlocked for UINavigationController, or navigationBar delegate set up incorrectly. Inconsistent configuration may cause problems. navigationController=<UINavigationController: 0x14c01ea00>, navigationBar=<UINavigationBar: 0x14aa1a280; frame = (0 59; 0 50); autoresize = W; backgroundColor = UIExtendedSRGBColorSpace 0.34902 0.368627 0.470588 1; layer = <CALayer: 0x600003434480>> delegate=0x14c01ea00`
  - 애플의 옛날 샘플 프로젝트에서도 뜨니 무시하겠습니다. 
<!-- 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술합니다. 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트를 요청하는 경우에 작성합니다. -->

## 스크린샷
![Simulator Screen Recording - iPhone 14 - 2022-11-22 at 16 16 37](https://user-images.githubusercontent.com/18394923/203249469-8fc5ef0f-6215-4fc8-9bf7-9400b311367e.gif)

<!-- 화면 전환이나 인터랙션이 있는 경우 GIF를, 정적인 화면이라면 스크린샷을 첨부합니다. -->
<!-- <img width="" alt="" src=""> -->
