### PR TITLE
[Design] 밴드상세화면의 상단뷰를 구현합니다

### DIFF
--- a/GetARock/GetARock.xcodeproj/project.pbxproj
+++ b/GetARock/GetARock.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		8437618D29273CF000BD2C2A /* GatheringCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8437618C29273CF000BD2C2A /* GatheringCell.xib */; };
 		8437619029275B3500BD2C2A /* GatheringCreatedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8437618F29275B3500BD2C2A /* GatheringCreatedViewController.swift */; };
 		8437619229276FA700BD2C2A /* GatheringCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8437619129276FA700BD2C2A /* GatheringCell.swift */; };
+		AB58E007292CB61700868720 /* TopViewOfInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB58E006292CB61700868720 /* TopViewOfInfoView.swift */; };
 		ABCE15B7292A052F007D30E2 /* ViewSwitchedSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCE15B6292A052F007D30E2 /* ViewSwitchedSegmentedControl.swift */; };
 		B830849929263B780035DB2D /* MainMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B830849829263B780035DB2D /* MainMapViewController.swift */; };
 		B8B9971F29287D3700082462 /* MainMap.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B8B9971E29287D3700082462 /* MainMap.storyboard */; };
@@ -106,6 +107,7 @@
 		8437618C29273CF000BD2C2A /* GatheringCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GatheringCell.xib; sourceTree = "<group>"; };
 		8437618F29275B3500BD2C2A /* GatheringCreatedViewController.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = GatheringCreatedViewController.swift; sourceTree = "<group>"; tabWidth = 4; };
 		8437619129276FA700BD2C2A /* GatheringCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatheringCell.swift; sourceTree = "<group>"; };
+		AB58E006292CB61700868720 /* TopViewOfInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopViewOfInfoView.swift; sourceTree = "<group>"; };
 		ABCE15B6292A052F007D30E2 /* ViewSwitchedSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewSwitchedSegmentedControl.swift; sourceTree = "<group>"; };
 		B830849829263B780035DB2D /* MainMapViewController.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = MainMapViewController.swift; sourceTree = "<group>"; tabWidth = 4; };
 		B8B9971E29287D3700082462 /* MainMap.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MainMap.storyboard; sourceTree = "<group>"; };
@@ -335,6 +337,7 @@
 			children = (
 				3DE5CE92292C511E005B448D /* Cell */,
 				3DE5CE91292C5112005B448D /* VC */,
+				AB58E006292CB61700868720 /* TopViewOfInfoView.swift */,
 			);
 			path = BandInfo;
 			sourceTree = "<group>";
@@ -554,6 +557,7 @@
 				3DF54FCB292A43EA001CD16B /* BandMemberCollectionViewCell.swift in Sources */,
 				3D0ED2232928667900AE320C /* BandInfoViewController.swift in Sources */,
 				0761508D29277CBB00A0562F /* VisitorComment.swift in Sources */,
+				AB58E007292CB61700868720 /* TopViewOfInfoView.swift in Sources */,
 				072DEDD2292687A70046A4A0 /* Location.swift in Sources */,
 				07D7DA3F29108CF800479B6F /* MyPageViewController.swift in Sources */,
 				072DEDD029267D9A0046A4A0 /* Band.swift in Sources */,

--- a/GetARock/GetARock.xcodeproj/project.pbxproj
+++ b/GetARock/GetARock.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		8437618D29273CF000BD2C2A /* GatheringCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8437618C29273CF000BD2C2A /* GatheringCell.xib */; };
 		8437619029275B3500BD2C2A /* GatheringCreatedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8437618F29275B3500BD2C2A /* GatheringCreatedViewController.swift */; };
 		8437619229276FA700BD2C2A /* GatheringCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8437619129276FA700BD2C2A /* GatheringCell.swift */; };
+		AB58E003292CB57100868720 /* BandPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB58E002292CB57100868720 /* BandPageViewController.swift */; };
 		AB58E007292CB61700868720 /* TopViewOfInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB58E006292CB61700868720 /* TopViewOfInfoView.swift */; };
 		ABCE15B7292A052F007D30E2 /* ViewSwitchedSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCE15B6292A052F007D30E2 /* ViewSwitchedSegmentedControl.swift */; };
 		B830849929263B780035DB2D /* MainMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B830849829263B780035DB2D /* MainMapViewController.swift */; };
@@ -107,6 +108,7 @@
 		8437618C29273CF000BD2C2A /* GatheringCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GatheringCell.xib; sourceTree = "<group>"; };
 		8437618F29275B3500BD2C2A /* GatheringCreatedViewController.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = GatheringCreatedViewController.swift; sourceTree = "<group>"; tabWidth = 4; };
 		8437619129276FA700BD2C2A /* GatheringCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatheringCell.swift; sourceTree = "<group>"; };
+		AB58E002292CB57100868720 /* BandPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandPageViewController.swift; sourceTree = "<group>"; };
 		AB58E006292CB61700868720 /* TopViewOfInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopViewOfInfoView.swift; sourceTree = "<group>"; };
 		ABCE15B6292A052F007D30E2 /* ViewSwitchedSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewSwitchedSegmentedControl.swift; sourceTree = "<group>"; };
 		B830849829263B780035DB2D /* MainMapViewController.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = MainMapViewController.swift; sourceTree = "<group>"; tabWidth = 4; };
@@ -346,6 +348,7 @@
 			isa = PBXGroup;
 			children = (
 				3D0ED2222928667900AE320C /* BandInfoViewController.swift */,
+				AB58E002292CB57100868720 /* BandPageViewController.swift */,
 			);
 			path = VC;
 			sourceTree = "<group>";
@@ -573,6 +576,7 @@
 				072DEDD429268F470046A4A0 /* PlayPosition.swift in Sources */,
 				07D7DA2D291088EC00479B6F /* NSObject+Extension.swift in Sources */,
 				07615093292907A900A0562F /* GatheringComment.swift in Sources */,
+				AB58E003292CB57100868720 /* BandPageViewController.swift in Sources */,
 				ABCE15B7292A052F007D30E2 /* ViewSwitchedSegmentedControl.swift in Sources */,
 				07D7DA3A29108C5B00479B6F /* BaseViewController.swift in Sources */,
 				07D7DA3429108A8300479B6F /* StringLiteral.swift in Sources */,

--- a/GetARock/GetARock/Screen/BandInfo/TopViewOfInfoView.swift
+++ b/GetARock/GetARock/Screen/BandInfo/TopViewOfInfoView.swift
@@ -25,7 +25,7 @@ final class TopViewOfInfoView: UIView {
         return $0
     }(UILabel())
     
-    private var dividedLine: UIView = {
+    private var divider: UIView = {
         $0.backgroundColor = .backgroundBlue
         $0.translatesAutoresizingMaskIntoConstraints = false
         return $0
@@ -47,7 +47,7 @@ extension TopViewOfInfoView {
     private func attribute() {
         addSubview(bandNameLabel)
         addSubview(bandLocationLabel)
-        addSubview(dividedLine)
+        addSubview(divider)
     }
     private func configureBandNameLabel() {
         NSLayoutConstraint.activate([
@@ -63,10 +63,10 @@ extension TopViewOfInfoView {
     }
     private func configureDividedLine() {
         NSLayoutConstraint.activate([
-            dividedLine.topAnchor.constraint(equalTo: bandLocationLabel.bottomAnchor, constant: 20),
-            dividedLine.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            dividedLine.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            dividedLine.heightAnchor.constraint(equalToConstant: 5)
+            divider.topAnchor.constraint(equalTo: bandLocationLabel.bottomAnchor, constant: 20),
+            divider.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            divider.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            divider.heightAnchor.constraint(equalToConstant: 5)
         ])
     }
     private func setupLayout() {

--- a/GetARock/GetARock/Screen/BandInfo/TopViewOfInfoView.swift
+++ b/GetARock/GetARock/Screen/BandInfo/TopViewOfInfoView.swift
@@ -1,0 +1,77 @@
+//
+//  TopViewOfInfoView.swift
+//  GetARock
+//
+//  Created by Somin Park on 2022/11/22.
+//
+
+import UIKit
+
+final class TopViewOfInfoView: UIView {
+    
+    // MARK: - Properties
+    
+    private var bandNameLabel: UILabel = {
+        $0.textColor = .white
+        $0.font = UIFont.systemFont(ofSize: 22, weight: .bold)
+        $0.translatesAutoresizingMaskIntoConstraints = false
+        return $0
+    }(UILabel())
+    
+    private var bandLocationLabel: UILabel = {
+        $0.textColor = .white
+        $0.font = UIFont.systemFont(ofSize: 14)
+        $0.translatesAutoresizingMaskIntoConstraints = false
+        return $0
+    }(UILabel())
+    
+    private var dividedLine: UIView = {
+        $0.backgroundColor = .backgroundBlue
+        $0.translatesAutoresizingMaskIntoConstraints = false
+        return $0
+    }(UIView())
+    
+    convenience init(bandName: String, bandLocation: String) {
+        self.init(frame: .zero)
+        self.bandNameLabel.text = bandName
+        self.bandLocationLabel.text = bandLocation
+        attribute()
+        setupLayout()
+    }
+
+}
+
+// MARK: - Layout
+
+extension TopViewOfInfoView {
+    private func attribute() {
+        addSubview(bandNameLabel)
+        addSubview(bandLocationLabel)
+        addSubview(dividedLine)
+    }
+    private func configureBandNameLabel() {
+        NSLayoutConstraint.activate([
+            bandNameLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: 40),
+            bandNameLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16)
+        ])
+    }
+    private func configureBandLocationLabel() {
+        NSLayoutConstraint.activate([
+            bandLocationLabel.topAnchor.constraint(equalTo: bandNameLabel.bottomAnchor, constant: 10),
+            bandLocationLabel.leadingAnchor.constraint(equalTo: bandNameLabel.leadingAnchor)
+        ])
+    }
+    private func configureDividedLine() {
+        NSLayoutConstraint.activate([
+            dividedLine.topAnchor.constraint(equalTo: bandLocationLabel.bottomAnchor, constant: 20),
+            dividedLine.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            dividedLine.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            dividedLine.heightAnchor.constraint(equalToConstant: 5)
+        ])
+    }
+    private func setupLayout() {
+        configureBandNameLabel()
+        configureBandLocationLabel()
+        configureDividedLine()
+    }
+}

--- a/GetARock/GetARock/Screen/BandInfo/VC/BandPageViewController.swift
+++ b/GetARock/GetARock/Screen/BandInfo/VC/BandPageViewController.swift
@@ -8,8 +8,12 @@
 import UIKit
 
 class BandPageViewController: UIViewController {
-
+    
+    // MARK: - View
+    
     private let topView = TopViewOfInfoView(bandName: "블랙로즈", bandLocation: "주소다주소야주소다주소야")
+    
+    // MARK: - View Life Cycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -17,6 +21,8 @@ class BandPageViewController: UIViewController {
     }
 
 }
+
+// MARK: - Layout
 
 extension BandPageViewController {
     private func configureTopView() {

--- a/GetARock/GetARock/Screen/BandInfo/VC/BandPageViewController.swift
+++ b/GetARock/GetARock/Screen/BandInfo/VC/BandPageViewController.swift
@@ -1,0 +1,36 @@
+//
+//  BandPageViewController.swift
+//  GetARock
+//
+//  Created by Somin Park on 2022/11/22.
+//
+
+import UIKit
+
+class BandPageViewController: UIViewController {
+
+    private let topView = TopViewOfInfoView(bandName: "블랙로즈", bandLocation: "주소다주소야주소다주소야")
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupLayout()
+    }
+
+}
+
+extension BandPageViewController {
+    private func configureTopView() {
+        topView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(topView)
+        NSLayoutConstraint.activate([
+            topView.topAnchor.constraint(equalTo: view.topAnchor),
+            topView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            topView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            topView.heightAnchor.constraint(equalToConstant: 130)
+        ])
+    }
+    private func setupLayout() {
+        view.backgroundColor = .modalBackgroundBlue
+        configureTopView()
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- close #78 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 배경

밴드 상세에서 밴드이름, 밴드주소가 보여지는 상단뷰를 구현했습니다.
<!-- PR과 관련된 논의 쓰레드, 디자인 가이드, 관련 PR 링크 등을 적어주세요 -->

## 작업 내용
👉🏻 TopViewOfInfoView 라는 UIView로 구현했습니다.
👉🏻 TopViewOfInfoView안에 밴드이름,주소는 label, 구분선은 UIView로 넣어놨습니다.

<!-- PR 작성 이유와 어떤 변경이 있었는지를 포함합니다. PR에 많은 변경이 있는 경우 추가되는 클래스들의 구조나 동작 등 자세하게 적는 경우도 있습니다 -->

## 테스트 방법
LandingViewController에 이 코드를 넣으면 시뮬레이터에서 확인하실 수 있습니다.
``` swift
private let topView = TopViewOfInfoView(bandName: "블랙로즈", bandLocation: "주소다주소야주소다주소야")
    
    override func viewDidLoad() {
        super.viewDidLoad()
        setupLayout()
    }

}

extension BandPageViewController {
    private func configureTopView() {
        topView.translatesAutoresizingMaskIntoConstraints = false
        view.addSubview(topView)
        NSLayoutConstraint.activate([
            topView.topAnchor.constraint(equalTo: view.topAnchor),
            topView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
            topView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
            topView.heightAnchor.constraint(equalToConstant: 130)
        ])
    }
    private func setupLayout() {
        view.backgroundColor = .modalBackgroundBlue
        configureTopView()
    }
```
<!-- PR 리뷰어가 이 PR의 변경사항을 확인할 수 있는 방법을 서술합니다. 의도하는 테스트 결과도 서술하면 더 좋습니다 -->

## 리뷰 노트

<!-- 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술합니다. 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트를 요청하는 경우에 작성합니다. -->

## 스크린샷

<img src="https://user-images.githubusercontent.com/69718283/203270253-43bce3da-736a-456d-bc57-228e708123fa.png" width="200"> 
<!-- 화면 전환이나 인터랙션이 있는 경우 GIF를, 정적인 화면이라면 스크린샷을 첨부합니다. -->
<!-- <img width="" alt="" src=""> -->
