### PR TITLE
[Fix] GatheringComment Model을 변경했습니다.

### DIFF
--- a/GetARock/GetARock/Network/Mock/Data/MockBandData.swift
+++ b/GetARock/GetARock/Network/Mock/Data/MockBandData.swift
@@ -293,7 +293,7 @@ enum MockData {
         GatheringCommentInfo(
             commentID: "gatheringCommentID-001",
             comment: GatheringComment(
-                gathering: gatherings[0].gathering,
+                gathering: gatherings[0],
                 author: bands[1],
                 content: "저희 밴드에서는 저 혼자만 가는데, 혹시 같이가도 괜찮을까요?",
                 createdAt: "2022.11.12 13:22".toDate(format: DateFormatLiteral.standard) ?? Date()
@@ -302,7 +302,7 @@ enum MockData {
         GatheringCommentInfo(
             commentID: "gatheringCommentID-002",
             comment: GatheringComment(
-                gathering: gatherings[0].gathering,
+                gathering: gatherings[0],
                 author: bands[0],
                 content: "물론이죠!",
                 createdAt: "2022.11.13 13:22".toDate(format: DateFormatLiteral.standard) ?? Date()
@@ -311,7 +311,7 @@ enum MockData {
         GatheringCommentInfo(
             commentID: "gatheringCommentID-003",
             comment: GatheringComment(
-                gathering: gatherings[0].gathering,
+                gathering: gatherings[0],
                 author: bands[0],
                 content:
                     """
@@ -323,7 +323,7 @@ enum MockData {
         GatheringCommentInfo(
             commentID: "gatheringCommentID-004",
             comment: GatheringComment(
-                gathering: gatherings[0].gathering,
+                gathering: gatherings[0],
                 author: bands[1],
                 content:
                     """

--- a/GetARock/GetARock/Network/Model/GatheringComment.swift
+++ b/GetARock/GetARock/Network/Model/GatheringComment.swift
@@ -13,7 +13,7 @@ struct GatheringCommentInfo {
 }
 
 struct GatheringComment {
-    let gathering: Gathering
+    let gathering: GatheringInfo
     let author: BandInfo
     let content: String
     let createdAt: Date


### PR DESCRIPTION
## 관련 이슈
- close #88 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 배경
현재 GatheringComment은
```Swift
struct GatheringCommentInfo {
    let commentID: String
    let comment: GatheringComment
}

struct GatheringComment {
    let gathering: Gathering
    let author: BandInfo
    let content: String
    let createdAt: Date
}
```
와 같은 형태입니다.
하지만, GatheringComment가 갖는 gathering 정보는 gathering의 내용 그자체보다는 해당 코멘트가 어떤 글의 코멘트인지를 식별하는 역할이 더 강합니다.
따라서, gathering 변수는 Gathering보다는 GatheringInfo를 값으로 갖는 것이 더 적절합니다.
<!-- PR과 관련된 논의 쓰레드, 디자인 가이드, 관련 PR 링크 등을 적어주세요 -->

## 작업 내용
GatheringComment 의 모델을 변경
- `let gathering: Gathering` -> `let gathering: GatheringInfo`

Mock데이터에서 해당 모델 변경 반영

<!-- PR 작성 이유와 어떤 변경이 있었는지를 포함합니다. PR에 많은 변경이 있는 경우 추가되는 클래스들의 구조나 동작 등 자세하게 적는 경우도 있습니다 -->

## 테스트 방법

<!-- PR 리뷰어가 이 PR의 변경사항을 확인할 수 있는 방법을 서술합니다. 의도하는 테스트 결과도 서술하면 더 좋습니다 -->

## 리뷰 노트

<!-- 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술합니다. 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트를 요청하는 경우에 작성합니다. -->

## 스크린샷

<!-- 화면 전환이나 인터랙션이 있는 경우 GIF를, 정적인 화면이라면 스크린샷을 첨부합니다. -->
<!-- <img width="" alt="" src=""> -->
