### PR TITLE
[Feat] 모여락 추가 뷰에서 완료를 눌렀을 때 모여락을 목데이터에 추가합니다.

### DIFF
--- a/GetARock/GetARock/Global/Resource/Storyboards/AddGathering.storyboard
+++ b/GetARock/GetARock/Global/Resource/Storyboards/AddGathering.storyboard
@@ -217,9 +217,13 @@
                         </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" title="완료" id="741-6a-MrW">
                             <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <connections>
+                                <action selector="saveButtonAction:" destination="Y6W-OH-hqX" id="Hd3-tf-mex"/>
+                            </connections>
                         </barButtonItem>
                     </navigationItem>
                     <connections>
+                        <outlet property="dateTimePicker" destination="s35-8k-0gb" id="LcY-0P-YHf"/>
                         <outlet property="hostBandNameLabel" destination="n7W-To-VFW" id="RSA-Hm-SvS"/>
                         <outlet property="introductionTextView" destination="uNV-iD-x50" id="NuI-MW-yqf"/>
                         <outlet property="scrollView" destination="teO-Fx-L4D" id="Pwm-8O-BPx"/>

--- a/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
+++ b/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
@@ -47,7 +47,11 @@ class AddGatheringViewController: UIViewController {
 
     @IBAction func cancelButtonAction(_ sender: UIBarButtonItem) {
         if introductionTextView.text.count > 0 || (titleTextField?.text ?? "").count > 0 || gatheringLocation != nil {
-            let cancelAlert = UIAlertController(title: nil, message: "작성중인 내용이 있습니다. 작성을 취소하시겠습니까?", preferredStyle: .alert)
+            let cancelAlert = UIAlertController(
+                title: nil,
+                message: "작성중인 내용이 있습니다. 작성을 취소하시겠습니까?",
+                preferredStyle: .alert
+            )
             let cancel = UIAlertAction(title: "아니오", style: .cancel)
             let confirm = UIAlertAction(title: "예", style: .destructive, handler: {_ in
                 self.dismiss(animated: true)
@@ -67,13 +71,20 @@ class AddGatheringViewController: UIViewController {
             alert.addAction(confirm)
             self.present(alert, animated: true)
         } else {
-            let gatheringAddTestGathering = Gathering(title: titleTextField.text ?? "이름없음",
-                                                        host: MockData.bands[0], // 테스트용, 추후 변경
-                                                        status: .recruiting,
-                                                        date: dateTimePicker.date,
-                                                        location: gatheringLocation ?? Location(name: "Default", address: "defaultAddress", additionalAddress: "defaultAdditionalAddress", coordinate: Coordinate(latitude: 36.01900, longitude: 129.34370)),
-                                                        introduction: introductionTextView.text,
-                                                        createdAt: Date())
+            let gatheringAddTestGathering = Gathering(
+                title: titleTextField.text ?? "이름없음",
+                host: MockData.bands[0], // 테스트용, 추후 변경
+                status: .recruiting,
+                date: dateTimePicker.date,
+                location: gatheringLocation ?? Location(
+                    name: "Default",
+                    address: "defaultAddress",
+                    additionalAddress: "defaultAdditionalAddress",
+                    coordinate: Coordinate(latitude: 36.01900, longitude: 129.34370)
+                ),
+                introduction: introductionTextView.text,
+                createdAt: Date()
+            )
             MockData.gatherings.append(GatheringInfo(gatheringID: "testID", gathering: gatheringAddTestGathering)) // 추후 변경
             printMockDataGatheringUpdateToTest() // 추후 삭제
             dismiss(animated: true)
@@ -122,8 +133,17 @@ extension AddGatheringViewController: UITextViewDelegate {
 
 extension AddGatheringViewController {
     private func getKeyboardNotification() {
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillShow(_:)),
+            name: UIResponder.keyboardWillShowNotification, object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillHide(_:)),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil
+        )
     }
 
     @objc func keyboardWillShow(_ sender: Notification) {
@@ -155,6 +175,7 @@ extension AddGatheringViewController {
 }
 
 // MARK: - Trivial utility method
+
 extension AddGatheringViewController {
     private func invalidInputErrorString() -> String? {
         enum Field: String {

--- a/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
+++ b/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
@@ -217,13 +217,10 @@ extension AddGatheringViewController {
     private func addGatheringInputErrorMessage() -> String? {
         do {
             try validateInputs()
-        } catch AddGatheringInputError.noMultipleFields {
-            return AddGatheringInputError.noMultipleFields.errorMessage
-        } catch AddGatheringInputError.noTitle {
-            return AddGatheringInputError.noTitle.errorMessage
-        } catch AddGatheringInputError.noLocation {
-            return AddGatheringInputError.noLocation.errorMessage
         } catch {
+            if let error = error as? AddGatheringInputError {
+                return error.errorMessage
+            }
             return "입력을 확인하는 중 알 수 없는 문제가 발생했습니다"
         }
         return nil

--- a/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
+++ b/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
@@ -38,7 +38,7 @@ class AddGatheringViewController: UIViewController {
         attribute()
         setDelegate()
         setupLayout()
-        setAddGatheringTestData() // 테스트용, 추후 삭제
+        setLocationToMockupData() // 위치 선택 구현 전 임시 위치 지정
     }
 
     deinit {
@@ -139,7 +139,8 @@ extension AddGatheringViewController {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(keyboardWillShow(_:)),
-            name: UIResponder.keyboardWillShowNotification, object: nil
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
         )
         NotificationCenter.default.addObserver(
             self,
@@ -232,7 +233,7 @@ extension AddGatheringViewController {
 // MARK: - Mock data set & test (위치 선택 구현 후 삭제 예정)
 
 extension AddGatheringViewController {
-    private func setAddGatheringTestData() {
+    private func setLocationToMockupData() {
         gatheringLocation = MockData.bands[1].band.location // 일부러 다른 밴드의 위치로 함
     }
 }

--- a/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
+++ b/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
@@ -184,6 +184,17 @@ extension AddGatheringViewController {
         case noTitle
         case noLocation
         case noMultipleFields
+        
+        var errorMessage: String {
+            switch self {
+            case .noTitle:
+                return "모여락의 이름을 입력해주세요"
+            case .noLocation:
+                return "모여락의 장소를 입력해주세요"
+            case .noMultipleFields:
+                return "모여락의 이름, 장소를 입력해주세요"
+            }
+        }
     }
 
     private func validateInputs() throws {
@@ -203,22 +214,18 @@ extension AddGatheringViewController {
     }
 
     private func addGatheringInputErrorMessage() -> String? {
-        var errorString = ""
         do {
             try validateInputs()
         } catch AddGatheringInputError.noMultipleFields {
-            errorString = "모여락의 이름, 장소를 입력해주세요"
+            return AddGatheringInputError.noMultipleFields.errorMessage
         } catch AddGatheringInputError.noTitle {
-            errorString = "모여락의 이름을 입력해주세요"
+            return AddGatheringInputError.noTitle.errorMessage
         } catch AddGatheringInputError.noLocation {
-            errorString = "모여락의 장소를 입력해주세요"
+            return AddGatheringInputError.noLocation.errorMessage
         } catch {
-            errorString = "입력을 확인하는 중 알 수 없는 문제가 발생했습니다"
+            return "입력을 확인하는 중 알 수 없는 문제가 발생했습니다"
         }
-        if errorString.count <= 0 {
-            return nil
-        }
-        return errorString
+        return nil
     }
 }
 

--- a/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
+++ b/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
@@ -9,6 +9,11 @@ import UIKit
 
 class AddGatheringViewController: UIViewController {
 
+    // MARK: - Property
+
+    private var hostBandName: String?
+    private var gatheringLocation: Location?
+
     // MARK: - View
 
     @IBOutlet weak var titleTextField: UITextField!
@@ -17,8 +22,6 @@ class AddGatheringViewController: UIViewController {
     @IBOutlet weak var introductionTextView: UITextView!
     @IBOutlet weak var scrollView: UIScrollView!
 
-    private var gatheringLocation: Location?
-    private var hostBandName: String?
     private let placeHolderLabel: UILabel = {
         $0.text = "내용을 입력하세요"
         $0.textColor = .lightGray

--- a/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
+++ b/GetARock/GetARock/Screen/AddGathering/AddGatheringViewController.swift
@@ -86,7 +86,6 @@ class AddGatheringViewController: UIViewController {
                 createdAt: Date()
             )
             MockData.gatherings.append(GatheringInfo(gatheringID: "testID", gathering: gatheringAddTestGathering)) // 추후 변경
-            printMockDataGatheringUpdateToTest() // 추후 삭제
             dismiss(animated: true)
         }
     }
@@ -220,23 +219,10 @@ extension AddGatheringViewController {
     }
 }
 
-// MARK: - Trivial utility method
-
-extension AddGatheringViewController {
-    #if DEBUG
-    // 로그를 보고 싶을 경우 주석 해제
-    private func printMockDataGatheringUpdateToTest() {
-//        print("before count: \(MockData.gatherings.count)")
-//        print("마지막: \(MockData.gatherings[MockData.gatherings.count-1])")
-    }
-    #endif
-}
-
 // MARK: - Mock data set & test (위치 선택 구현 후 삭제 예정)
 
 extension AddGatheringViewController {
     private func setAddGatheringTestData() {
         gatheringLocation = MockData.bands[1].band.location // 일부러 다른 밴드의 위치로 함
-        printMockDataGatheringUpdateToTest()
     }
 }


### PR DESCRIPTION
## 관련 이슈
- close #39 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 배경
모여락(밴드 이벤트) 추가 뷰에서 유저가 입력한 정보를 새 모여락으로 저장합니다. 
<!-- PR과 관련된 논의 쓰레드, 디자인 가이드, 관련 PR 링크 등을 적어주세요 -->

## 작업 내용
- [ ] 완료버튼을 눌렀을 때 목업데이터 모여락에 추가
- [ ] 제목이나 장소가 없거나, 모임 일시가 저장시점 보다 이른 경우 알림을 띄우고 저장하지 않습니다. 
  - 메시지 내용은 편하게 적어서 필요하면 추후 다른 이슈로 수정하려고 합니다. 
- [ ] 제목이나 내용이 있는 경우 취소를 눌렀을 때 정말 닫을 것인지 알림으로 물어봅니다. 
 - 모달을 내려서 해제하는 경우는 다루지 않았습니다. 
<!-- PR 작성 이유와 어떤 변경이 있었는지를 포함합니다. PR에 많은 변경이 있는 경우 추가되는 클래스들의 구조나 동작 등 자세하게 적는 경우도 있습니다 -->

## 테스트 방법
추천: Landing 에 버튼과 storyboard reference를 추가하여 AddGathering 스토리보드와 present로 연결하면 모달로 뜹니다. 

MockData.gatherings의 가장 마지막 element를 콘솔에 찍는 함수를 뷰컨트롤러에 복붙에 사용합니다.
- 추천: viewDidLoad에서 1회, 저장시 1회 실행
```swift
extension AddGatheringViewController {
    private func printMockDataGatheringUpdateToTest() {
        print("before count: \(MockData.gatherings.count)")
        print("마지막: \(MockData.gatherings[MockData.gatherings.count-1])")
    }
}
```

<!-- PR 리뷰어가 이 PR의 변경사항을 확인할 수 있는 방법을 서술합니다. 의도하는 테스트 결과도 서술하면 더 좋습니다 -->

## 리뷰 노트
- 구현되지 않은 부분(위치설정)을 위해 뷰컨트롤러 가장 아래에 임시 함수를 넣어두었는데, 다른 좋은 방법이 있으면 알려주세요. 
- 로그 찍는 함수도 그 바로 위에 넣었는데, 이러고 머지를 해도 되는지, 추가하지 않고 PR에 적거나 다른 방법이 있는지 궁금합니다. 
- 에러스트링 만드는 함수도 편하게 추가할 수 있는 것이 있으면 알려주시면 감사합니다. 
- 모달 내릴 때도 내용이 있으면 경고를 띄우면 좋겠는데, 서버가 없을 때 우선순위가 낮은 것 같습니다. 취소에서의 알림도 뺄까요?
<!-- 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술합니다. 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트를 요청하는 경우에 작성합니다. -->

## 스크린샷
![Simulator Screen Recording - 6s-15 0 - 2022-11-23 at 20 10 08](https://user-images.githubusercontent.com/18394923/203532371-da3167cc-ff9c-45b1-ac3f-f0faecab765e.gif)
<img width="1268" alt="Screenshot 2022-11-23 at 8 08 58 PM" src="https://user-images.githubusercontent.com/18394923/203532387-6f17895a-19ac-4947-a8d0-77a0e2b2bd58.png">

<!-- 화면 전환이나 인터랙션이 있는 경우 GIF를, 정적인 화면이라면 스크린샷을 첨부합니다. -->
<!-- <img width="" alt="" src=""> -->
