### PR TITLE
[Add] 지도 뷰에서 현재 위치를 텍스트로 보여줍니다.

### DIFF
--- a/GetARock/GetARock/Global/Resource/Storyboards/MainMap.storyboard
+++ b/GetARock/GetARock/Global/Resource/Storyboards/MainMap.storyboard
@@ -84,6 +84,7 @@
                     <connections>
                         <outlet property="attendedEventListButton" destination="knR-dY-MnG" id="zQz-hF-EXv"/>
                         <outlet property="createEventButton" destination="CbB-be-MPA" id="wgp-QK-rhW"/>
+                        <outlet property="locationLabel" destination="vTY-ql-DKb" id="Bqc-HP-it4"/>
                         <outlet property="mapView" destination="hqG-Ca-tqo" id="FvX-hf-hxu"/>
                         <outlet property="myPageButton" destination="CPO-gF-m3Y" id="Bj2-Eu-vQ8"/>
                     </connections>

--- a/GetARock/GetARock/Screen/MainMap/Component/AnnotationView.swift
+++ b/GetARock/GetARock/Screen/MainMap/Component/AnnotationView.swift
@@ -52,7 +52,7 @@ class CustomAnnotation: NSObject, MKAnnotation {
     let coordinate: CLLocationCoordinate2D
     let category: Category
     
-    init(title: String?, coordinate: CLLocationCoordinate2D, category: Category) {
+    init(title: String, coordinate: CLLocationCoordinate2D, category: Category) {
         self.title = title
         self.coordinate = coordinate
         self.category = category

--- a/GetARock/GetARock/Screen/MainMap/CustomAnnotationView.swift
+++ b/GetARock/GetARock/Screen/MainMap/CustomAnnotationView.swift
@@ -26,6 +26,7 @@ class CustomAnnotationView: MKMarkerAnnotationView {
 }
 
 class CustomAnnotation: NSObject, MKAnnotation {
+    
     enum Category {
         case band
         case gathering
@@ -47,10 +48,9 @@ class CustomAnnotation: NSObject, MKAnnotation {
         }
     }
     
+    let title: String?
     let coordinate: CLLocationCoordinate2D
     let category: Category
-    
-    var title: String?
     
     init(title: String?, coordinate: CLLocationCoordinate2D, category: Category) {
         self.title = title

--- a/GetARock/GetARock/Screen/MainMap/MainMapViewController.swift
+++ b/GetARock/GetARock/Screen/MainMap/MainMapViewController.swift
@@ -159,7 +159,7 @@ extension MainMapViewController: CLLocationManagerDelegate {
 
 extension MainMapViewController: MKMapViewDelegate {
     func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
-        if annotation as? MKUserLocation != nil {
+        if annotation is MKUserLocation {
             return MKUserLocationView()
         }
         

--- a/GetARock/GetARock/Screen/MainMap/MainMapViewController.swift
+++ b/GetARock/GetARock/Screen/MainMap/MainMapViewController.swift
@@ -139,11 +139,11 @@ extension MainMapViewController: CLLocationManagerDelegate {
             completionHandler: {(placemarks, _) -> Void in
                 let currentPlacemark = placemarks?.first
                 var address: String = ""
-                if currentPlacemark!.locality != nil {
+                if currentPlacemark?.locality != nil {
                     address += " "
                     address += currentPlacemark!.locality!
                 }
-                if currentPlacemark!.thoroughfare != nil {
+                if currentPlacemark?.thoroughfare != nil {
                     address += " "
                     address += currentPlacemark!.thoroughfare!
                 }

--- a/GetARock/GetARock/Screen/MainMap/MainMapViewController.swift
+++ b/GetARock/GetARock/Screen/MainMap/MainMapViewController.swift
@@ -13,6 +13,7 @@ final class MainMapViewController: UIViewController {
     
     // MARK: - Properties
     
+    @IBOutlet weak var locationLabel: UILabel!
     @IBOutlet weak var mapView: MKMapView!
     @IBOutlet weak var createEventButton: UIButton!
     @IBOutlet weak var attendedEventListButton: UIButton!
@@ -130,6 +131,28 @@ extension MainMapViewController: CLLocationManagerDelegate {
         }
     }
     
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        let currentLocation = locations.last
+        
+        CLGeocoder().reverseGeocodeLocation(
+            currentLocation!,
+            completionHandler: {(placemarks, _) -> Void in
+                let currentPlacemark = placemarks!.first
+                var address: String = ""
+                if currentPlacemark!.locality != nil {
+                    address += " "
+                    address += currentPlacemark!.locality!
+                }
+                if currentPlacemark!.thoroughfare != nil {
+                    address += " "
+                    address += currentPlacemark!.thoroughfare!
+                }
+                
+                self.locationLabel.text = address
+            }
+        )
+    }
+
 }
 
 // MARK: - CLLocationManagerDelegate

--- a/GetARock/GetARock/Screen/MainMap/MainMapViewController.swift
+++ b/GetARock/GetARock/Screen/MainMap/MainMapViewController.swift
@@ -137,7 +137,7 @@ extension MainMapViewController: CLLocationManagerDelegate {
         CLGeocoder().reverseGeocodeLocation(
             currentLocation!,
             completionHandler: {(placemarks, _) -> Void in
-                let currentPlacemark = placemarks!.first
+                let currentPlacemark = placemarks?.first
                 var address: String = ""
                 if currentPlacemark!.locality != nil {
                     address += " "

--- a/GetARock/GetARock/Screen/MainMap/MainMapViewController.swift
+++ b/GetARock/GetARock/Screen/MainMap/MainMapViewController.swift
@@ -137,15 +137,15 @@ extension MainMapViewController: CLLocationManagerDelegate {
         CLGeocoder().reverseGeocodeLocation(
             currentLocation!,
             completionHandler: {(placemarks, _) -> Void in
-                let currentPlacemark = placemarks?.first
+                guard let currentPlacemark = placemarks?.first else { return }
                 var address: String = ""
-                if currentPlacemark?.locality != nil {
+                if currentPlacemark.locality != nil {
                     address += " "
-                    address += currentPlacemark!.locality!
+                    address += currentPlacemark.locality!
                 }
-                if currentPlacemark?.thoroughfare != nil {
+                if currentPlacemark.thoroughfare != nil {
                     address += " "
-                    address += currentPlacemark!.thoroughfare!
+                    address += currentPlacemark.thoroughfare!
                 }
                 
                 self.locationLabel.text = address


### PR DESCRIPTION
## 관련 이슈
- close #97 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 배경
지도 뷰에서 `현재 위치`를 텍스트로 보여줍니다.  

<img width="362" alt="image" src="https://user-images.githubusercontent.com/51108729/203568562-b66b3b74-57d4-4917-a0ec-56b6091ee617.png">

<!-- PR과 관련된 논의 쓰레드, 디자인 가이드, 관련 PR 링크 등을 적어주세요 -->

## 작업 내용
- 현재 위치를 주소로 변환한 후, `city + street name` 으로 지도 뷰에 보여줍니다. e.g. 포항시 지곡로

<!-- PR 작성 이유와 어떤 변경이 있었는지를 포함합니다. PR에 많은 변경이 있는 경우 추가되는 클래스들의 구조나 동작 등 자세하게 적는 경우도 있습니다 -->

## 테스트 방법
스토리보드로 작업했습니다.  

`Info.plist` → `Application Scene Manifest` → `Scene Configuration` → 
`Application Session Role` → `Item` → `Storyboard Name` 을 `MainMap` 으로 변경하시면 확인하실 수 있습니다.  
<!-- PR 리뷰어가 이 PR의 변경사항을 확인할 수 있는 방법을 서술합니다. 의도하는 테스트 결과도 서술하면 더 좋습니다 -->

<!-- PR 리뷰어가 이 PR의 변경사항을 확인할 수 있는 방법을 서술합니다. 의도하는 테스트 결과도 서술하면 더 좋습니다 -->

## 리뷰 노트
- 2022.11.24 02:56 기준으로 이전 [PR](https://github.com/DeveloperAcademy-POSTECH/MacC-GetARock/pull/96) 코드가 포함되어 있는 상태입니다... 이전 PR 부터 리뷰해주세요..🥺
- 추후 젠리처럼... 지도에 포커스된 위치 정보를 보여주고 싶습니다.. (지도 이동하면 그 위치 정보를 텍스트로 보여주도록)
<!-- 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술합니다. 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트를 요청하는 경우에 작성합니다. -->

## 스크린샷
 <img width="250" src="https://user-images.githubusercontent.com/51108729/203616030-8cbfc47e-275e-47a7-aa4f-5f65b09e09b2.PNG">

<!-- 화면 전환이나 인터랙션이 있는 경우 GIF를, 정적인 화면이라면 스크린샷을 첨부합니다. -->
<!-- <img width="" alt="" src=""> -->
