### PR TITLE
[Feat] 내모여락 리스트에 항목들을 목데이터에서 불러올 수 있도록 인터페이스를 만들었습니다.

### DIFF
--- a/GetARock/GetARock.xcodeproj/project.pbxproj
+++ b/GetARock/GetARock.xcodeproj/project.pbxproj
@@ -36,27 +36,27 @@
 		07D7DA832911EB7D00479B6F /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 07D7DA822911EB7D00479B6F /* .swiftlint.yml */; };
 		3D0ED2232928667900AE320C /* BandInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0ED2222928667900AE320C /* BandInfoViewController.swift */; };
 		3D565329292855E9003D0C9F /* BandInfo.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3D565328292855E9003D0C9F /* BandInfo.storyboard */; };
+		3DF54FCB292A43EA001CD16B /* BandMemberCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF54FCA292A43EA001CD16B /* BandMemberCollectionViewCell.swift */; };
+		6667A3202929F5DA0052A53B /* GatheringInfoPage.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6667A31F2929F5DA0052A53B /* GatheringInfoPage.storyboard */; };
+		66E1623F292ADFF5001F0578 /* GatheringInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E1623E292ADFF5001F0578 /* GatheringInfoViewController.swift */; };
 		7BB7099329290AE40065136D /* CommentListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB7099229290AE40065136D /* CommentListView.swift */; };
 		7BB709972929164D0065136D /* CommentTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB709962929164D0065136D /* CommentTableViewCell.swift */; };
 		7BB70999292A419B0065136D /* EmptyListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB70998292A419B0065136D /* EmptyListView.swift */; };
 		7BB7099B292A47E50065136D /* CommentCreateButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB7099A292A47E40065136D /* CommentCreateButton.swift */; };
-		3DF54FCB292A43EA001CD16B /* BandMemberCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF54FCA292A43EA001CD16B /* BandMemberCollectionViewCell.swift */; };
-		6667A3202929F5DA0052A53B /* GatheringInfoPage.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6667A31F2929F5DA0052A53B /* GatheringInfoPage.storyboard */; };
-		66E1623F292ADFF5001F0578 /* GatheringInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E1623E292ADFF5001F0578 /* GatheringInfoViewController.swift */; };
 		7BDA8F8B291284FE00BB2D34 /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BDA8F8A291284FE00BB2D34 /* UIColor+Extension.swift */; };
 		7BDA8F90291296B200BB2D34 /* UIView+Gradation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BDA8F8F291296B200BB2D34 /* UIView+Gradation.swift */; };
+		7BFDAA91292C94E5002FE744 /* CommentWritingPopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFDAA90292C94E5002FE744 /* CommentWritingPopupViewController.swift */; };
 		84002600292BB27B0093648A /* BandTimeline.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 840025FF292BB27B0093648A /* BandTimeline.storyboard */; };
 		84002602292BB3DB0093648A /* BandTimelineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84002601292BB3DB0093648A /* BandTimelineViewController.swift */; };
 		84002606292BB75C0093648A /* BandTimelineCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 84002605292BB75C0093648A /* BandTimelineCell.xib */; };
 		84002608292BC4BE0093648A /* BandTimelineCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84002607292BC4BE0093648A /* BandTimelineCell.swift */; };
-		8437618B2927397400BD2C2A /* GatheringView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8437618A2927397400BD2C2A /* GatheringView.storyboard */; };
-		8437618D29273CF000BD2C2A /* GatheringCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8437618C29273CF000BD2C2A /* GatheringCell.xib */; };
-		8437619029275B3500BD2C2A /* GatheringCreatedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8437618F29275B3500BD2C2A /* GatheringCreatedViewController.swift */; };
-		8437619229276FA700BD2C2A /* GatheringCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8437619129276FA700BD2C2A /* GatheringCell.swift */; };
+		8437618B2927397400BD2C2A /* GatheringList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8437618A2927397400BD2C2A /* GatheringList.storyboard */; };
+		8437618D29273CF000BD2C2A /* GatheringListCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8437618C29273CF000BD2C2A /* GatheringListCell.xib */; };
+		8437619029275B3500BD2C2A /* GatheringListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8437618F29275B3500BD2C2A /* GatheringListViewController.swift */; };
+		8437619229276FA700BD2C2A /* GatheringListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8437619129276FA700BD2C2A /* GatheringListCell.swift */; };
 		AB58E003292CB57100868720 /* BandPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB58E002292CB57100868720 /* BandPageViewController.swift */; };
 		AB58E007292CB61700868720 /* TopViewOfInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB58E006292CB61700868720 /* TopViewOfInfoView.swift */; };
 		ABCE15B7292A052F007D30E2 /* ViewSwitchedSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCE15B6292A052F007D30E2 /* ViewSwitchedSegmentedControl.swift */; };
-		7BFDAA91292C94E5002FE744 /* CommentWritingPopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFDAA90292C94E5002FE744 /* CommentWritingPopupViewController.swift */; };
 		B830849929263B780035DB2D /* MainMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B830849829263B780035DB2D /* MainMapViewController.swift */; };
 		B8B9971F29287D3700082462 /* MainMap.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B8B9971E29287D3700082462 /* MainMap.storyboard */; };
 		C5C7AC6B292A7F7C00698636 /* AddGathering.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C5C7AC6A292A7F7C00698636 /* AddGathering.storyboard */; };
@@ -114,27 +114,27 @@
 		07D7DA822911EB7D00479B6F /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		3D0ED2222928667900AE320C /* BandInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandInfoViewController.swift; sourceTree = "<group>"; };
 		3D565328292855E9003D0C9F /* BandInfo.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = BandInfo.storyboard; sourceTree = "<group>"; };
+		3DF54FCA292A43EA001CD16B /* BandMemberCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandMemberCollectionViewCell.swift; sourceTree = "<group>"; };
+		6667A31F2929F5DA0052A53B /* GatheringInfoPage.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = GatheringInfoPage.storyboard; sourceTree = "<group>"; };
+		66E1623E292ADFF5001F0578 /* GatheringInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatheringInfoViewController.swift; sourceTree = "<group>"; };
 		7BB7099229290AE40065136D /* CommentListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentListView.swift; sourceTree = "<group>"; };
 		7BB709962929164D0065136D /* CommentTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentTableViewCell.swift; sourceTree = "<group>"; };
 		7BB70998292A419B0065136D /* EmptyListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyListView.swift; sourceTree = "<group>"; };
 		7BB7099A292A47E40065136D /* CommentCreateButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentCreateButton.swift; sourceTree = "<group>"; };
-		3DF54FCA292A43EA001CD16B /* BandMemberCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandMemberCollectionViewCell.swift; sourceTree = "<group>"; };
-		6667A31F2929F5DA0052A53B /* GatheringInfoPage.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = GatheringInfoPage.storyboard; sourceTree = "<group>"; };
-		66E1623E292ADFF5001F0578 /* GatheringInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatheringInfoViewController.swift; sourceTree = "<group>"; };
 		7BDA8F8A291284FE00BB2D34 /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
 		7BDA8F8F291296B200BB2D34 /* UIView+Gradation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Gradation.swift"; sourceTree = "<group>"; };
+		7BFDAA90292C94E5002FE744 /* CommentWritingPopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentWritingPopupViewController.swift; sourceTree = "<group>"; };
 		840025FF292BB27B0093648A /* BandTimeline.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = BandTimeline.storyboard; sourceTree = "<group>"; };
 		84002601292BB3DB0093648A /* BandTimelineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandTimelineViewController.swift; sourceTree = "<group>"; };
 		84002605292BB75C0093648A /* BandTimelineCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BandTimelineCell.xib; sourceTree = "<group>"; };
 		84002607292BC4BE0093648A /* BandTimelineCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandTimelineCell.swift; sourceTree = "<group>"; };
-		8437618A2927397400BD2C2A /* GatheringView.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = GatheringView.storyboard; sourceTree = "<group>"; };
-		8437618C29273CF000BD2C2A /* GatheringCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GatheringCell.xib; sourceTree = "<group>"; };
-		8437618F29275B3500BD2C2A /* GatheringCreatedViewController.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = GatheringCreatedViewController.swift; sourceTree = "<group>"; tabWidth = 4; };
-		8437619129276FA700BD2C2A /* GatheringCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatheringCell.swift; sourceTree = "<group>"; };
+		8437618A2927397400BD2C2A /* GatheringList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = GatheringList.storyboard; sourceTree = "<group>"; };
+		8437618C29273CF000BD2C2A /* GatheringListCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GatheringListCell.xib; sourceTree = "<group>"; };
+		8437618F29275B3500BD2C2A /* GatheringListViewController.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = GatheringListViewController.swift; sourceTree = "<group>"; tabWidth = 4; };
+		8437619129276FA700BD2C2A /* GatheringListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatheringListCell.swift; sourceTree = "<group>"; };
 		AB58E002292CB57100868720 /* BandPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandPageViewController.swift; sourceTree = "<group>"; };
 		AB58E006292CB61700868720 /* TopViewOfInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopViewOfInfoView.swift; sourceTree = "<group>"; };
 		ABCE15B6292A052F007D30E2 /* ViewSwitchedSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewSwitchedSegmentedControl.swift; sourceTree = "<group>"; };
-		7BFDAA90292C94E5002FE744 /* CommentWritingPopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentWritingPopupViewController.swift; sourceTree = "<group>"; };
 		B830849829263B780035DB2D /* MainMapViewController.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = MainMapViewController.swift; sourceTree = "<group>"; tabWidth = 4; };
 		B8B9971E29287D3700082462 /* MainMap.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MainMap.storyboard; sourceTree = "<group>"; };
 		C5C7AC6A292A7F7C00698636 /* AddGathering.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = AddGathering.storyboard; sourceTree = "<group>"; };
@@ -312,7 +312,7 @@
 				840025FF292BB27B0093648A /* BandTimeline.storyboard */,
 				B8B9971E29287D3700082462 /* MainMap.storyboard */,
 				C5C7AC6A292A7F7C00698636 /* AddGathering.storyboard */,
-				8437618A2927397400BD2C2A /* GatheringView.storyboard */,
+				8437618A2927397400BD2C2A /* GatheringList.storyboard */,
 			);
 			path = Storyboards;
 			sourceTree = "<group>";
@@ -378,7 +378,7 @@
 			children = (
 				07D7DA4329108DCB00479B6F /* SampleView.xib */,
 				84002605292BB75C0093648A /* BandTimelineCell.xib */,
-				8437618C29273CF000BD2C2A /* GatheringCell.xib */,
+				8437618C29273CF000BD2C2A /* GatheringListCell.xib */,
 			);
 			path = Xibs;
 			sourceTree = "<group>";
@@ -393,19 +393,11 @@
 			path = BandInfo;
 			sourceTree = "<group>";
 		};
-		7BB709952929161D0065136D /* Cell */ = {
-			isa = PBXGroup;
-			children = (
-				7BB709962929164D0065136D /* CommentTableViewCell.swift */,
-                );
-            path = Cell;
-            sourceTree = "<group>";
-        };
 		3DE5CE91292C5112005B448D /* VC */ = {
 			isa = PBXGroup;
 			children = (
 				3D0ED2222928667900AE320C /* BandInfoViewController.swift */,
-        84002601292BB3DB0093648A /* BandTimelineViewController.swift */,
+				84002601292BB3DB0093648A /* BandTimelineViewController.swift */,
 				AB58E002292CB57100868720 /* BandPageViewController.swift */,
 			);
 			path = VC;
@@ -415,7 +407,7 @@
 			isa = PBXGroup;
 			children = (
 				3DF54FCA292A43EA001CD16B /* BandMemberCollectionViewCell.swift */,
-        84002607292BC4BE0093648A /* BandTimelineCell.swift */,
+				84002607292BC4BE0093648A /* BandTimelineCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -426,6 +418,14 @@
 				66E1623E292ADFF5001F0578 /* GatheringInfoViewController.swift */,
 			);
 			path = GatheringInfo;
+			sourceTree = "<group>";
+		};
+		7BB709952929161D0065136D /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				7BB709962929164D0065136D /* CommentTableViewCell.swift */,
+			);
+			path = Cell;
 			sourceTree = "<group>";
 		};
 		7BDA8F8E291296A200BB2D34 /* Utils */ = {
@@ -440,8 +440,8 @@
 		8437618E2927551100BD2C2A /* Gathering */ = {
 			isa = PBXGroup;
 			children = (
-				8437618F29275B3500BD2C2A /* GatheringCreatedViewController.swift */,
-				8437619129276FA700BD2C2A /* GatheringCell.swift */,
+				8437618F29275B3500BD2C2A /* GatheringListViewController.swift */,
+				8437619129276FA700BD2C2A /* GatheringListCell.swift */,
 			);
 			path = Gathering;
 			sourceTree = "<group>";
@@ -567,11 +567,11 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8437618B2927397400BD2C2A /* GatheringView.storyboard in Resources */,
+				8437618B2927397400BD2C2A /* GatheringList.storyboard in Resources */,
 				07D7DA832911EB7D00479B6F /* .swiftlint.yml in Resources */,
 				B8B9971F29287D3700082462 /* MainMap.storyboard in Resources */,
 				84002600292BB27B0093648A /* BandTimeline.storyboard in Resources */,
-				8437618D29273CF000BD2C2A /* GatheringCell.xib in Resources */,
+				8437618D29273CF000BD2C2A /* GatheringListCell.xib in Resources */,
 				07D7D9EF290FB8C400479B6F /* LaunchScreen.storyboard in Resources */,
 				07D7DA4429108DCB00479B6F /* SampleView.xib in Resources */,
 				6667A3202929F5DA0052A53B /* GatheringInfoPage.storyboard in Resources */,
@@ -626,8 +626,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				66E1623F292ADFF5001F0578 /* GatheringInfoViewController.swift in Sources */,
-				8437619229276FA700BD2C2A /* GatheringCell.swift in Sources */,
-				8437619029275B3500BD2C2A /* GatheringCreatedViewController.swift in Sources */,
+				8437619229276FA700BD2C2A /* GatheringListCell.swift in Sources */,
+				8437619029275B3500BD2C2A /* GatheringListViewController.swift in Sources */,
 				07D7DA3C29108C9000479B6F /* SampleView.swift in Sources */,
 				3DF54FCB292A43EA001CD16B /* BandMemberCollectionViewCell.swift in Sources */,
 				3D0ED2232928667900AE320C /* BandInfoViewController.swift in Sources */,

--- a/GetARock/GetARock.xcodeproj/project.pbxproj
+++ b/GetARock/GetARock.xcodeproj/project.pbxproj
@@ -37,18 +37,17 @@
 		3D0ED2232928667900AE320C /* BandInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0ED2222928667900AE320C /* BandInfoViewController.swift */; };
 		3D565329292855E9003D0C9F /* BandInfo.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3D565328292855E9003D0C9F /* BandInfo.storyboard */; };
 		3DF54FCB292A43EA001CD16B /* BandMemberCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF54FCA292A43EA001CD16B /* BandMemberCollectionViewCell.swift */; };
+		3DF54FCF292B9223001CD16B /* RepertoireTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF54FCE292B9223001CD16B /* RepertoireTableViewCell.swift */; };
+		3DF54FD1292BAFA6001CD16B /* RepertoireTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3DF54FD0292BAFA6001CD16B /* RepertoireTableViewCell.xib */; };
 		6606F855292CB38B00A121BF /* ReportReasonListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6606F853292CB38B00A121BF /* ReportReasonListCell.swift */; };
 		6606F856292CB38B00A121BF /* ReportReasonListCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6606F854292CB38B00A121BF /* ReportReasonListCell.xib */; };
 		66285ABE292DE9F100029213 /* ReportReasonListHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = 66285ABD292DE9F100029213 /* ReportReasonListHeader.xib */; };
 		6667A3202929F5DA0052A53B /* GatheringInfoPage.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6667A31F2929F5DA0052A53B /* GatheringInfoPage.storyboard */; };
-		66E1623F292ADFF5001F0578 /* GatheringInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E1623E292ADFF5001F0578 /* GatheringInfoViewController.swift */; };
 		66E74206292C82E8003C0B02 /* ActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E74205292C82E8003C0B02 /* ActionSheet.swift */; };
 		66E74208292C9F12003C0B02 /* ReportReasonList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 66E74207292C9F12003C0B02 /* ReportReasonList.storyboard */; };
 		66E7420A292CA04D003C0B02 /* ReportReasonListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E74209292CA04D003C0B02 /* ReportReasonListController.swift */; };
-		3DF54FCF292B9223001CD16B /* RepertoireTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF54FCE292B9223001CD16B /* RepertoireTableViewCell.swift */; };
-		3DF54FD1292BAFA6001CD16B /* RepertoireTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3DF54FD0292BAFA6001CD16B /* RepertoireTableViewCell.xib */; };
+		7B04C330292D0C1F00EA2590 /* VisitorCommentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B04C32F292D0C1F00EA2590 /* VisitorCommentViewController.swift */; };
 		7BB7099329290AE40065136D /* CommentListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB7099229290AE40065136D /* CommentListView.swift */; };
-        7B04C330292D0C1F00EA2590 /* VisitorCommentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B04C32F292D0C1F00EA2590 /* VisitorCommentViewController.swift */; };
 		7BB709972929164D0065136D /* CommentTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB709962929164D0065136D /* CommentTableViewCell.swift */; };
 		7BB70999292A419B0065136D /* EmptyListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB70998292A419B0065136D /* EmptyListView.swift */; };
 		7BB7099B292A47E50065136D /* CommentCreateButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB7099A292A47E40065136D /* CommentCreateButton.swift */; };
@@ -59,15 +58,10 @@
 		84002602292BB3DB0093648A /* BandTimelineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84002601292BB3DB0093648A /* BandTimelineViewController.swift */; };
 		84002606292BB75C0093648A /* BandTimelineCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 84002605292BB75C0093648A /* BandTimelineCell.xib */; };
 		84002608292BC4BE0093648A /* BandTimelineCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84002607292BC4BE0093648A /* BandTimelineCell.swift */; };
-		7BFDAA91292C94E5002FE744 /* CommentWritingPopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFDAA90292C94E5002FE744 /* CommentWritingPopupViewController.swift */; };
-		8437618B2927397400BD2C2A /* GatheringView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8437618A2927397400BD2C2A /* GatheringView.storyboard */; };
-		8437618D29273CF000BD2C2A /* GatheringCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8437618C29273CF000BD2C2A /* GatheringCell.xib */; };
-		8437619029275B3500BD2C2A /* GatheringCreatedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8437618F29275B3500BD2C2A /* GatheringCreatedViewController.swift */; };
-		8437619229276FA700BD2C2A /* GatheringCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8437619129276FA700BD2C2A /* GatheringCell.swift */; };
-		8437618B2927397400BD2C2A /* GatheringList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8437618A2927397400BD2C2A /* GatheringList.storyboard */; };
 		8437618D29273CF000BD2C2A /* GatheringListCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8437618C29273CF000BD2C2A /* GatheringListCell.xib */; };
-		8437619029275B3500BD2C2A /* GatheringListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8437618F29275B3500BD2C2A /* GatheringListViewController.swift */; };
-		8437619229276FA700BD2C2A /* GatheringListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8437619129276FA700BD2C2A /* GatheringListCell.swift */; };
+		84880526293B6C6D0085C718 /* GatheringListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8437618F29275B3500BD2C2A /* GatheringListViewController.swift */; };
+		84880527293B6C750085C718 /* GatheringListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8437619129276FA700BD2C2A /* GatheringListCell.swift */; };
+		84880528293B6C930085C718 /* GatheringList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8437618A2927397400BD2C2A /* GatheringList.storyboard */; };
 		AB58E003292CB57100868720 /* BandPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB58E002292CB57100868720 /* BandPageViewController.swift */; };
 		AB58E007292CB61700868720 /* TopViewOfInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB58E006292CB61700868720 /* TopViewOfInfoView.swift */; };
 		ABCE15B7292A052F007D30E2 /* ViewSwitchedSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCE15B6292A052F007D30E2 /* ViewSwitchedSegmentedControl.swift */; };
@@ -130,6 +124,8 @@
 		3D0ED2222928667900AE320C /* BandInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandInfoViewController.swift; sourceTree = "<group>"; };
 		3D565328292855E9003D0C9F /* BandInfo.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = BandInfo.storyboard; sourceTree = "<group>"; };
 		3DF54FCA292A43EA001CD16B /* BandMemberCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandMemberCollectionViewCell.swift; sourceTree = "<group>"; };
+		3DF54FCE292B9223001CD16B /* RepertoireTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepertoireTableViewCell.swift; sourceTree = "<group>"; };
+		3DF54FD0292BAFA6001CD16B /* RepertoireTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RepertoireTableViewCell.xib; sourceTree = "<group>"; };
 		6606F853292CB38B00A121BF /* ReportReasonListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportReasonListCell.swift; sourceTree = "<group>"; };
 		6606F854292CB38B00A121BF /* ReportReasonListCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReportReasonListCell.xib; sourceTree = "<group>"; };
 		66285ABD292DE9F100029213 /* ReportReasonListHeader.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReportReasonListHeader.xib; sourceTree = "<group>"; };
@@ -138,8 +134,6 @@
 		66E74205292C82E8003C0B02 /* ActionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionSheet.swift; sourceTree = "<group>"; };
 		66E74207292C9F12003C0B02 /* ReportReasonList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ReportReasonList.storyboard; sourceTree = "<group>"; };
 		66E74209292CA04D003C0B02 /* ReportReasonListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportReasonListController.swift; sourceTree = "<group>"; };
-		3DF54FCE292B9223001CD16B /* RepertoireTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepertoireTableViewCell.swift; sourceTree = "<group>"; };
-		3DF54FD0292BAFA6001CD16B /* RepertoireTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RepertoireTableViewCell.xib; sourceTree = "<group>"; };
 		7B04C32F292D0C1F00EA2590 /* VisitorCommentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorCommentViewController.swift; sourceTree = "<group>"; };
 		7BB7099229290AE40065136D /* CommentListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentListView.swift; sourceTree = "<group>"; };
 		7BB709962929164D0065136D /* CommentTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentTableViewCell.swift; sourceTree = "<group>"; };
@@ -152,11 +146,6 @@
 		84002601292BB3DB0093648A /* BandTimelineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandTimelineViewController.swift; sourceTree = "<group>"; };
 		84002605292BB75C0093648A /* BandTimelineCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BandTimelineCell.xib; sourceTree = "<group>"; };
 		84002607292BC4BE0093648A /* BandTimelineCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandTimelineCell.swift; sourceTree = "<group>"; };
-		7BFDAA90292C94E5002FE744 /* CommentWritingPopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentWritingPopupViewController.swift; sourceTree = "<group>"; };
-		8437618A2927397400BD2C2A /* GatheringView.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = GatheringView.storyboard; sourceTree = "<group>"; };
-		8437618C29273CF000BD2C2A /* GatheringCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GatheringCell.xib; sourceTree = "<group>"; };
-		8437618F29275B3500BD2C2A /* GatheringCreatedViewController.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = GatheringCreatedViewController.swift; sourceTree = "<group>"; tabWidth = 4; };
-		8437619129276FA700BD2C2A /* GatheringCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatheringCell.swift; sourceTree = "<group>"; };
 		8437618A2927397400BD2C2A /* GatheringList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = GatheringList.storyboard; sourceTree = "<group>"; };
 		8437618C29273CF000BD2C2A /* GatheringListCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GatheringListCell.xib; sourceTree = "<group>"; };
 		8437618F29275B3500BD2C2A /* GatheringListViewController.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = GatheringListViewController.swift; sourceTree = "<group>"; tabWidth = 4; };
@@ -342,7 +331,6 @@
 				840025FF292BB27B0093648A /* BandTimeline.storyboard */,
 				B8B9971E29287D3700082462 /* MainMap.storyboard */,
 				C5C7AC6A292A7F7C00698636 /* AddGathering.storyboard */,
-				8437618A2927397400BD2C2A /* GatheringView.storyboard */,
 				66E74207292C9F12003C0B02 /* ReportReasonList.storyboard */,
 				8437618A2927397400BD2C2A /* GatheringList.storyboard */,
 			);
@@ -379,7 +367,6 @@
 			isa = PBXGroup;
 			children = (
 				07D7DA3B29108C9000479B6F /* SampleView.swift */,
-				ABCE15B6292A052F007D30E2 /* ViewSwitchedSegmentedControl.swift */,
 				7BB7099229290AE40065136D /* CommentListView.swift */,
 				7BB70998292A419B0065136D /* EmptyListView.swift */,
 				7BB7099A292A47E40065136D /* CommentCreateButton.swift */,
@@ -413,7 +400,6 @@
 				07D7DA4329108DCB00479B6F /* SampleView.xib */,
 				3DF54FD0292BAFA6001CD16B /* RepertoireTableViewCell.xib */,
 				84002605292BB75C0093648A /* BandTimelineCell.xib */,
-				8437618C29273CF000BD2C2A /* GatheringCell.xib */,
 				6606F854292CB38B00A121BF /* ReportReasonListCell.xib */,
 				66285ABD292DE9F100029213 /* ReportReasonListHeader.xib */,
 				8437618C29273CF000BD2C2A /* GatheringListCell.xib */,
@@ -448,14 +434,6 @@
 				3DF54FCA292A43EA001CD16B /* BandMemberCollectionViewCell.swift */,
 				3DF54FCE292B9223001CD16B /* RepertoireTableViewCell.swift */,
 				84002607292BC4BE0093648A /* BandTimelineCell.swift */,
-			);
-			path = Cell;
-			sourceTree = "<group>";
-		};
-		7BB709952929161D0065136D /* Cell */ = {
-			isa = PBXGroup;
-			children = (
-				7BB709962929164D0065136D /* CommentTableViewCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -626,9 +604,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8437618B2927397400BD2C2A /* GatheringView.storyboard in Resources */,
+				84880528293B6C930085C718 /* GatheringList.storyboard in Resources */,
 				66E74208292C9F12003C0B02 /* ReportReasonList.storyboard in Resources */,
-				8437618B2927397400BD2C2A /* GatheringList.storyboard in Resources */,
 				07D7DA832911EB7D00479B6F /* .swiftlint.yml in Resources */,
 				3DF54FD1292BAFA6001CD16B /* RepertoireTableViewCell.xib in Resources */,
 				B8B9971F29287D3700082462 /* MainMap.storyboard in Resources */,
@@ -689,13 +666,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				66E1623F292ADFF5001F0578 /* GatheringInfoViewController.swift in Sources */,
+				84880527293B6C750085C718 /* GatheringListCell.swift in Sources */,
+				84880526293B6C6D0085C718 /* GatheringListViewController.swift in Sources */,
 				6606F855292CB38B00A121BF /* ReportReasonListCell.swift in Sources */,
 				66E7420A292CA04D003C0B02 /* ReportReasonListController.swift in Sources */,
-				8437619229276FA700BD2C2A /* GatheringCell.swift in Sources */,
-				8437619029275B3500BD2C2A /* GatheringCreatedViewController.swift in Sources */,
-				8437619229276FA700BD2C2A /* GatheringListCell.swift in Sources */,
-				8437619029275B3500BD2C2A /* GatheringListViewController.swift in Sources */,
 				07D7DA3C29108C9000479B6F /* SampleView.swift in Sources */,
 				3DF54FCB292A43EA001CD16B /* BandMemberCollectionViewCell.swift in Sources */,
 				3DF54FCF292B9223001CD16B /* RepertoireTableViewCell.swift in Sources */,

--- a/GetARock/GetARock/Global/Resource/Storyboards/GatheringList.storyboard
+++ b/GetARock/GetARock/Global/Resource/Storyboards/GatheringList.storyboard
@@ -9,10 +9,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Gathering Created View Controller-->
+        <!--Gathering List View Controller-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
-                <viewController id="Y6W-OH-hqX" customClass="GatheringCreatedViewController" customModule="GetARock" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="Y6W-OH-hqX" customClass="GatheringListViewController" customModule="GetARock" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/GetARock/GetARock/Global/Resource/Storyboards/GatheringList.storyboard
+++ b/GetARock/GetARock/Global/Resource/Storyboards/GatheringList.storyboard
@@ -19,6 +19,7 @@
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" estimatedSectionHeaderHeight="-1" sectionFooterHeight="28" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="HPt-wu-fhy">
                                 <rect key="frame" x="0.0" y="48" width="414" height="814"/>
+                                <color key="backgroundColor" red="0.35294118520000001" green="0.3686274886" blue="0.46274507050000002" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <color key="separatorColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <inset key="separatorInset" minX="16" minY="0.0" maxX="16" maxY="0.0"/>
                                 <connections>

--- a/GetARock/GetARock/Global/Resource/Storyboards/GatheringView.storyboard
+++ b/GetARock/GetARock/Global/Resource/Storyboards/GatheringView.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>

--- a/GetARock/GetARock/Global/Resource/Xibs/GatheringCell.xib
+++ b/GetARock/GetARock/Global/Resource/Xibs/GatheringCell.xib
@@ -76,9 +76,9 @@
                 </constraints>
             </tableViewCellContentView>
             <connections>
-                <outlet property="startTime" destination="QDG-Zm-Xit" id="IWd-Ev-Hsv"/>
-                <outlet property="state" destination="ngk-mQ-50w" id="0Hq-mb-dAf"/>
-                <outlet property="title" destination="ngk-mQ-50w" id="cok-bI-bw6"/>
+                <outlet property="startTime" destination="QDG-Zm-Xit" id="mTK-Ty-GXh"/>
+                <outlet property="state" destination="ngk-mQ-50w" id="fAy-1n-0Dv"/>
+                <outlet property="title" destination="4Wl-Jv-4Rb" id="RBd-yB-RMf"/>
             </connections>
             <point key="canvasLocation" x="442.02898550724643" y="124.55357142857142"/>
         </tableViewCell>

--- a/GetARock/GetARock/Global/Resource/Xibs/GatheringListCell.xib
+++ b/GetARock/GetARock/Global/Resource/Xibs/GatheringListCell.xib
@@ -10,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="GatheringCell" rowHeight="118" id="S08-fi-dea" customClass="GatheringCell" customModule="GetARock" customModuleProvider="target">
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="GatheringListCell" rowHeight="118" id="S08-fi-dea" customClass="GatheringListCell" customModule="GetARock" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="414" height="100"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="S08-fi-dea" id="0NC-3l-Vgg">

--- a/GetARock/GetARock/Global/Resource/Xibs/GatheringListCell.xib
+++ b/GetARock/GetARock/Global/Resource/Xibs/GatheringListCell.xib
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,7 +16,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bolt.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="WHj-3l-xcL">
-                        <rect key="frame" x="36" y="21" width="15" height="16.5"/>
+                        <rect key="frame" x="36" y="21.666666666666668" width="15" height="15.999999999999996"/>
                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="15" id="6k2-u3-ZXE"/>
@@ -32,7 +30,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="동성로 합동 버스킹 합니다!" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Wl-Jv-4Rb">
-                        <rect key="frame" x="36" y="47" width="169.5" height="20"/>
+                        <rect key="frame" x="36" y="47" width="169.33333333333334" height="20"/>
                         <constraints>
                             <constraint firstAttribute="width" relation="lessThanOrEqual" constant="250" id="6Hj-xV-rvP"/>
                         </constraints>
@@ -41,7 +39,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ngk-mQ-50w">
-                        <rect key="frame" x="308" y="32.5" width="70" height="35"/>
+                        <rect key="frame" x="308" y="32.666666666666664" width="70" height="34.999999999999993"/>
                         <color key="backgroundColor" systemColor="systemPurpleColor"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="35" id="5cz-gA-TOc"/>
@@ -76,9 +74,9 @@
                 </constraints>
             </tableViewCellContentView>
             <connections>
-                <outlet property="startTime" destination="QDG-Zm-Xit" id="mTK-Ty-GXh"/>
-                <outlet property="state" destination="ngk-mQ-50w" id="fAy-1n-0Dv"/>
-                <outlet property="title" destination="4Wl-Jv-4Rb" id="RBd-yB-RMf"/>
+                <outlet property="dateLabel" destination="QDG-Zm-Xit" id="mTK-Ty-GXh"/>
+                <outlet property="statusLabel" destination="ngk-mQ-50w" id="fAy-1n-0Dv"/>
+                <outlet property="titleLabel" destination="4Wl-Jv-4Rb" id="RBd-yB-RMf"/>
             </connections>
             <point key="canvasLocation" x="442.02898550724643" y="124.55357142857142"/>
         </tableViewCell>

--- a/GetARock/GetARock/Global/Resource/Xibs/GatheringListCell.xib
+++ b/GetARock/GetARock/Global/Resource/Xibs/GatheringListCell.xib
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -31,9 +33,6 @@
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="동성로 합동 버스킹 합니다!" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Wl-Jv-4Rb">
                         <rect key="frame" x="36" y="47" width="169.33333333333334" height="20"/>
-                        <constraints>
-                            <constraint firstAttribute="width" relation="lessThanOrEqual" constant="250" id="6Hj-xV-rvP"/>
-                        </constraints>
                         <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <nil key="highlightedColor"/>
@@ -68,6 +67,7 @@
                     <constraint firstItem="QDG-Zm-Xit" firstAttribute="top" secondItem="0NC-3l-Vgg" secondAttribute="top" constant="22" id="Dn0-fj-lYA"/>
                     <constraint firstItem="ngk-mQ-50w" firstAttribute="centerY" secondItem="0NC-3l-Vgg" secondAttribute="centerY" id="Tt7-ww-09a"/>
                     <constraint firstItem="4Wl-Jv-4Rb" firstAttribute="top" secondItem="QDG-Zm-Xit" secondAttribute="bottom" constant="10" id="VEO-NA-R6h"/>
+                    <constraint firstItem="ngk-mQ-50w" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="4Wl-Jv-4Rb" secondAttribute="trailing" constant="10" id="ajP-HL-Bzr"/>
                     <constraint firstAttribute="bottomMargin" secondItem="4Wl-Jv-4Rb" secondAttribute="bottom" constant="22" id="jhJ-Bt-RHG"/>
                     <constraint firstItem="WHj-3l-xcL" firstAttribute="top" secondItem="0NC-3l-Vgg" secondAttribute="top" constant="22" id="qEK-8D-ARD"/>
                     <constraint firstItem="4Wl-Jv-4Rb" firstAttribute="leading" secondItem="0NC-3l-Vgg" secondAttribute="leading" constant="36" id="xqo-0u-pPV"/>

--- a/GetARock/GetARock/Screen/Gathering/GatheringListCell.swift
+++ b/GetARock/GetARock/Screen/Gathering/GatheringListCell.swift
@@ -9,9 +9,9 @@ import UIKit
 
 class GatheringListCell: UITableViewCell {
 
-    @IBOutlet weak var startTime: UILabel!
-    @IBOutlet weak var title: UILabel!
-    @IBOutlet weak var state: UILabel!
+    @IBOutlet weak var dateLabel: UILabel!
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var statusLabel: UILabel!
     
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/GetARock/GetARock/Screen/Gathering/GatheringListCell.swift
+++ b/GetARock/GetARock/Screen/Gathering/GatheringListCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class GatheringCell: UITableViewCell {
+class GatheringListCell: UITableViewCell {
 
     @IBOutlet weak var startTime: UILabel!
     @IBOutlet weak var title: UILabel!

--- a/GetARock/GetARock/Screen/Gathering/GatheringListViewController.swift
+++ b/GetARock/GetARock/Screen/Gathering/GatheringListViewController.swift
@@ -13,47 +13,6 @@ class GatheringListViewController: UIViewController {
     
     @IBOutlet weak var tableView: UITableView!
     
-    // MARK: - Sample Data
-    
-    enum StateType {
-        case finding
-        case active
-        case finish
-        case cancel
-    }
-    
-    struct Gathering {
-        var title: String
-        var date: String
-        var state: StateType
-        
-        init(title: String, date: String, state: StateType) {
-            self.title = title
-            self.date = date
-            self.state = state
-        }
-    }
-    
-    private var gathering = [
-        Gathering(title: "동성로 합동 버스킹 합니다!", date: "22.12.05 13:00", state: .finding),
-        Gathering(title: "블랙로즈 합주 드럼 한 분 구합니다", date: "22.11.20 14:00", state: .active),
-        Gathering(title: "몰라 아무거나 쳐보는 중입니다.", date: "22.11.20 12:00", state: .active),
-        Gathering(title: "두 줄 만들기 해보는 중, 몰라 아무거나 쳐보는 중입니다1234.", date: "22.11.18 21:00", state: .cancel),
-        Gathering(title: "대체텍스트 대체텍스트 대체텍스트", date: "22.11.18 16:00", state: .finish),
-        Gathering(title: "두 줄 만들기 대체텍스트 대체텍스트 대체텍스트 대체텍스트 대체텍스트 22", date: "22.11.12 18:00", state: .finish)
-    ]
-    
-    func labelType(for type: StateType) -> String {
-        let text: String
-        switch type {
-        case .finding: text = "모집중"
-        case .active: text = "진행중"
-        case .finish: text = "완 료"
-        case .cancel: text = "취소됨"
-        }
-        return text
-    }
-    
     // MARK: - View Life Cycle
     
     override func viewDidLoad() {
@@ -69,15 +28,16 @@ class GatheringListViewController: UIViewController {
 
 extension GatheringListViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return gathering.count
+//        return gathering.count
+        return 1
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: GatheringListCell.className, for: indexPath) as? GatheringListCell else { return UITableViewCell() }
         
-        cell.title.text = gathering[indexPath.row].title
-        cell.startTime.text = gathering[indexPath.row].date
-        cell.state.text = labelType(for: gathering[indexPath.row].state)
+//        cell.title.text = gathering[indexPath.row].title
+//        cell.startTime.text = gathering[indexPath.row].date
+//        cell.state.text = labelType(for: gathering[indexPath.row].state)
         
         return cell
     }

--- a/GetARock/GetARock/Screen/Gathering/GatheringListViewController.swift
+++ b/GetARock/GetARock/Screen/Gathering/GatheringListViewController.swift
@@ -11,7 +11,7 @@ class GatheringListViewController: UIViewController {
     
     // MARK: - Properties
     
-    @IBOutlet weak var tableView: UITableView!
+    @IBOutlet private weak var tableView: UITableView!
     
     var gatheringInfos: [GatheringInfo] = []
     

--- a/GetARock/GetARock/Screen/Gathering/GatheringListViewController.swift
+++ b/GetARock/GetARock/Screen/Gathering/GatheringListViewController.swift
@@ -24,6 +24,11 @@ class GatheringListViewController: UIViewController {
         tableView.register(nibName, forCellReuseIdentifier: GatheringListCell.className)
     }
     
+    // MARK: - View Reload
+    
+    func reloadTableView() {
+        tableView.reloadData()
+    }
 }
 
 // MARK: - UITableViewDataSource

--- a/GetARock/GetARock/Screen/Gathering/GatheringListViewController.swift
+++ b/GetARock/GetARock/Screen/Gathering/GatheringListViewController.swift
@@ -24,7 +24,7 @@ class GatheringListViewController: UIViewController {
         tableView.register(nibName, forCellReuseIdentifier: GatheringListCell.className)
     }
     
-    // MARK: - View Reload
+    // MARK: - Method
     
     func reloadTableView() {
         tableView.reloadData()

--- a/GetARock/GetARock/Screen/Gathering/GatheringListViewController.swift
+++ b/GetARock/GetARock/Screen/Gathering/GatheringListViewController.swift
@@ -37,9 +37,9 @@ extension GatheringListViewController: UITableViewDataSource {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: GatheringListCell.className, for: indexPath) as? GatheringListCell else { return UITableViewCell() }
         
         let gathering = gatheringInfos[indexPath.row].gathering
-        cell.title.text = gathering.title
-        cell.startTime.text = gathering.date.toString(format: DateFormatLiteral.standard)
-        cell.state.text = gathering.status.toKorean()
+        cell.titleLabel.text = gathering.title
+        cell.dateLabel.text = gathering.date.toString(format: DateFormatLiteral.standard)
+        cell.statusLabel.text = gathering.status.toKorean()
         
         return cell
     }

--- a/GetARock/GetARock/Screen/Gathering/GatheringListViewController.swift
+++ b/GetARock/GetARock/Screen/Gathering/GatheringListViewController.swift
@@ -13,6 +13,8 @@ class GatheringListViewController: UIViewController {
     
     @IBOutlet weak var tableView: UITableView!
     
+    var gathering: [Gathering]?
+    
     // MARK: - View Life Cycle
     
     override func viewDidLoad() {
@@ -28,16 +30,16 @@ class GatheringListViewController: UIViewController {
 
 extension GatheringListViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-//        return gathering.count
-        return 1
+        return gathering?.count ?? 0
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: GatheringListCell.className, for: indexPath) as? GatheringListCell else { return UITableViewCell() }
         
-//        cell.title.text = gathering[indexPath.row].title
-//        cell.startTime.text = gathering[indexPath.row].date
-//        cell.state.text = labelType(for: gathering[indexPath.row].state)
+        guard let gatheringInfo = gathering?[indexPath.row] else { return UITableViewCell() }
+        cell.title.text = gatheringInfo.title
+        cell.startTime.text = gatheringInfo.date.toString(format: DateFormatLiteral.standard)
+        cell.state.text = gatheringInfo.status.toKorean()
         
         return cell
     }

--- a/GetARock/GetARock/Screen/Gathering/GatheringListViewController.swift
+++ b/GetARock/GetARock/Screen/Gathering/GatheringListViewController.swift
@@ -49,9 +49,3 @@ extension GatheringListViewController: UITableViewDataSource {
         return cell
     }
 }
-
-// MARK: - UITableViewDelegate
-
-extension GatheringListViewController: UITableViewDelegate {
-    
-}

--- a/GetARock/GetARock/Screen/Gathering/GatheringListViewController.swift
+++ b/GetARock/GetARock/Screen/Gathering/GatheringListViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class GatheringCreatedViewController: UIViewController {
+class GatheringListViewController: UIViewController {
     
     // MARK: - Properties
     
@@ -59,21 +59,21 @@ class GatheringCreatedViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        let nibName = UINib(nibName: "GatheringCell", bundle: nil)
-        tableView.register(nibName, forCellReuseIdentifier: GatheringCell.className)
+        let nibName = UINib(nibName: "GatheringListCell", bundle: nil)
+        tableView.register(nibName, forCellReuseIdentifier: GatheringListCell.className)
     }
     
 }
 
 // MARK: - UITableViewDataSource
 
-extension GatheringCreatedViewController: UITableViewDataSource {
+extension GatheringListViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return gathering.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: GatheringCell.className, for: indexPath) as? GatheringCell else { return UITableViewCell() }
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: GatheringListCell.className, for: indexPath) as? GatheringListCell else { return UITableViewCell() }
         
         cell.title.text = gathering[indexPath.row].title
         cell.startTime.text = gathering[indexPath.row].date
@@ -85,6 +85,6 @@ extension GatheringCreatedViewController: UITableViewDataSource {
 
 // MARK: - UITableViewDelegate
 
-extension GatheringCreatedViewController: UITableViewDelegate {
+extension GatheringListViewController: UITableViewDelegate {
     
 }

--- a/GetARock/GetARock/Screen/Gathering/GatheringListViewController.swift
+++ b/GetARock/GetARock/Screen/Gathering/GatheringListViewController.swift
@@ -13,7 +13,7 @@ class GatheringListViewController: UIViewController {
     
     @IBOutlet weak var tableView: UITableView!
     
-    var gathering: [Gathering]?
+    var gatheringInfos: [GatheringInfo] = []
     
     // MARK: - View Life Cycle
     
@@ -30,16 +30,16 @@ class GatheringListViewController: UIViewController {
 
 extension GatheringListViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return gathering?.count ?? 0
+        return gatheringInfos.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: GatheringListCell.className, for: indexPath) as? GatheringListCell else { return UITableViewCell() }
         
-        guard let gatheringInfo = gathering?[indexPath.row] else { return UITableViewCell() }
-        cell.title.text = gatheringInfo.title
-        cell.startTime.text = gatheringInfo.date.toString(format: DateFormatLiteral.standard)
-        cell.state.text = gatheringInfo.status.toKorean()
+        let gathering = gatheringInfos[indexPath.row].gathering
+        cell.title.text = gathering.title
+        cell.startTime.text = gathering.date.toString(format: DateFormatLiteral.standard)
+        cell.state.text = gathering.status.toKorean()
         
         return cell
     }


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- #107 

## 배경
<!-- PR과 관련된 논의 쓰레드, 디자인 가이드, 관련 PR 링크 등을 적어주세요 -->
내모여락 버튼 클릭 시 나오게 되는 리스트 항목 뷰를 목데이터와 연결합니다.

## 작업 내용
<!-- PR 작성 이유와 어떤 변경이 있었는지를 포함합니다. PR에 많은 변경이 있는 경우 추가되는 클래스들의 구조나 동작 등 자세하게 적는 경우도 있습니다 -->
- 내모여락 ViewController 안에 있던 임시데이터 삭제
- 이벤트 정보 리스트 값을 넘겨받을 수 있도록 변수 설정 후 MockData 형식으로 받아서 출력가능하도록 구현
- 변수에는 초기값을 넣어주면서 후처리 코드가 더 깔끔해지도록 구현

## 테스트 방법
<!-- PR 리뷰어가 이 PR의 변경사항을 확인할 수 있는 방법을 서술합니다. 의도하는 테스트 결과도 서술하면 더 좋습니다 -->
기존 방식과 동일하게 시작 스토리보드를 "GatheringList"로 설정하고 실행하면 됩니다.
```
window!.rootViewController = UIStoryboard(name: "GatheringList", bundle: nil).instantiateInitialViewController()!
```
데이터 초기값이 빈 배열이므로 값을 넣어서 확인하고 싶다면,
GatheringListViewController.swift 에서
`var gatheringInfos: [GatheringInfo] = []`를 
`var gatheringInfos: [GatheringInfo] = MockData.gatherings`로 변경후에 실행하면 값이 들어간 화면을 볼 수 있습니다.

## 리뷰 노트
<!-- 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술합니다. 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트를 요청하는 경우에 작성합니다. -->
- Storyboard 네이밍의 경우 기존의 GatheringView 뒤에 "Veiw"가 붙는 것이 다른 Storyboard 네이밍과 다른 느낌을 받아서 GatheringList로 변경했습니다.
- ViewController의 경우 기존에 각기 다른 데이터를 받는 서로 다른 ViewController를 만들 생각으로 GatheringCreatedViewController, GatheringAttendViewController 등으로 만들 예정이었는데, 같은 뷰를 사용하되 다른 데이터만 넘겨주면 되는 방식으로 구현하게 되면서 네이밍을 GatheringListViewController로 변경했습니다.
- 클래스 내에 reloadTableView()라는 함수를 구현해서 추후 넣어주는 데이터 값이 달라질 때 (MockData 추가, 변경 시), 리로드 할 수 있도록 구현했습니다.

## 스크린샷
<!-- 화면 전환이나 인터랙션이 있는 경우 GIF를, 정적인 화면이라면 스크린샷을 첨부합니다. -->
<img width="300" alt="" src="https://user-images.githubusercontent.com/29690062/203697486-c52f4851-ffe2-4f30-b804-72d0c14fd358.png">

