### PR TITLE
[Feat] 밴드 타임라인에 항목들을 목데이터에서 불러올 수 있도록 인터페이스를 만들었습니다.

### DIFF
--- a/GetARock/GetARock/Global/Resource/Storyboards/BandTimeline.storyboard
+++ b/GetARock/GetARock/Global/Resource/Storyboards/BandTimeline.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>

--- a/GetARock/GetARock/Global/Resource/Storyboards/BandTimeline.storyboard
+++ b/GetARock/GetARock/Global/Resource/Storyboards/BandTimeline.storyboard
@@ -19,7 +19,7 @@
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="FUY-jI-anN">
                                 <rect key="frame" x="0.0" y="59" width="393" height="759"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="backgroundColor" red="0.35294118520000001" green="0.3686274886" blue="0.46274507050000002" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <connections>
                                     <outlet property="dataSource" destination="Y6W-OH-hqX" id="2as-Qa-kVx"/>
                                     <outlet property="delegate" destination="Y6W-OH-hqX" id="eKe-ow-1bC"/>

--- a/GetARock/GetARock/Global/Resource/Xibs/BandTimelineCell.xib
+++ b/GetARock/GetARock/Global/Resource/Xibs/BandTimelineCell.xib
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -109,9 +107,9 @@
             <color key="backgroundColor" red="0.35294118520000001" green="0.3686274886" blue="0.46274507050000002" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
             <connections>
                 <outlet property="bottomLine" destination="Fpk-HD-t04" id="Dvj-gx-caD"/>
-                <outlet property="startTime" destination="np7-Hm-tCg" id="QJA-NZ-exa"/>
-                <outlet property="status" destination="JSI-YD-u1h" id="Rw1-m3-fCX"/>
-                <outlet property="title" destination="Gsv-TT-DTS" id="5M5-YG-3TT"/>
+                <outlet property="dateLabel" destination="np7-Hm-tCg" id="QJA-NZ-exa"/>
+                <outlet property="statusLabel" destination="JSI-YD-u1h" id="Rw1-m3-fCX"/>
+                <outlet property="titleLabel" destination="Gsv-TT-DTS" id="5M5-YG-3TT"/>
                 <outlet property="topLine" destination="Qwo-tI-wkK" id="g67-Yv-x8B"/>
             </connections>
             <point key="canvasLocation" x="118.32061068702289" y="45.774647887323944"/>

--- a/GetARock/GetARock/Global/Resource/Xibs/BandTimelineCell.xib
+++ b/GetARock/GetARock/Global/Resource/Xibs/BandTimelineCell.xib
@@ -54,9 +54,6 @@
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="동성로 합동 버스킹 합니다!" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gsv-TT-DTS">
                         <rect key="frame" x="64.000000000000014" y="50.666666666666664" width="169.33333333333337" height="19.333333333333336"/>
-                        <constraints>
-                            <constraint firstAttribute="width" relation="lessThanOrEqual" constant="210" id="Mqs-78-qLP"/>
-                        </constraints>
                         <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <nil key="highlightedColor"/>
@@ -94,6 +91,7 @@
                     <constraint firstItem="Fpk-HD-t04" firstAttribute="centerX" secondItem="rfp-Pd-07t" secondAttribute="centerX" id="hcf-U9-fa7"/>
                     <constraint firstItem="np7-Hm-tCg" firstAttribute="leading" secondItem="FlR-MG-Sew" secondAttribute="trailing" constant="4" id="ipX-st-2IL"/>
                     <constraint firstItem="Gsv-TT-DTS" firstAttribute="top" secondItem="FlR-MG-Sew" secondAttribute="bottom" constant="5.6699999999999999" id="kRU-ax-5iM"/>
+                    <constraint firstItem="JSI-YD-u1h" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Gsv-TT-DTS" secondAttribute="trailing" constant="10" id="lh2-GO-1DS"/>
                     <constraint firstItem="Gsv-TT-DTS" firstAttribute="leading" secondItem="FlR-MG-Sew" secondAttribute="leading" id="m5V-AW-SEA"/>
                     <constraint firstItem="FlR-MG-Sew" firstAttribute="leading" secondItem="rfp-Pd-07t" secondAttribute="trailing" constant="28" id="nh2-G6-SWA"/>
                     <constraint firstItem="np7-Hm-tCg" firstAttribute="top" secondItem="c8z-EJ-itS" secondAttribute="top" constant="30" id="oWM-V2-at2"/>

--- a/GetARock/GetARock/Screen/BandInfo/Cell/BandTimelineCell.swift
+++ b/GetARock/GetARock/Screen/BandInfo/Cell/BandTimelineCell.swift
@@ -9,9 +9,9 @@ import UIKit
 
 class BandTimelineCell: UITableViewCell {
 
-    @IBOutlet weak var startTime: UILabel!
-    @IBOutlet weak var title: UILabel!
-    @IBOutlet weak var status: UILabel!
+    @IBOutlet weak var dateLabel: UILabel!
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var statusLabel: UILabel!
     @IBOutlet weak var topLine: UIView!
     @IBOutlet weak var bottomLine: UIView!
     

--- a/GetARock/GetARock/Screen/BandInfo/VC/BandTimelineViewController.swift
+++ b/GetARock/GetARock/Screen/BandInfo/VC/BandTimelineViewController.swift
@@ -20,6 +20,12 @@ class BandTimelineViewController: UIViewController {
         let nibName = UINib(nibName: "BandTimelineCell", bundle: nil)
         tableView.register(nibName, forCellReuseIdentifier: BandTimelineCell.className)
     }
+    
+    // MARK: - View Reload
+    
+    func reloadTableView() {
+        tableView.reloadData()
+    }
 }
 
 // MARK: - UITableViewDataSource

--- a/GetARock/GetARock/Screen/BandInfo/VC/BandTimelineViewController.swift
+++ b/GetARock/GetARock/Screen/BandInfo/VC/BandTimelineViewController.swift
@@ -51,7 +51,8 @@ extension BandTimelineViewController: UITableViewDataSource {
 
         if indexPath.row == 0 {
             cell.topLine.isHidden = true
-        } else if indexPath.row == (gatheringInfos.count) - 1 {
+        }
+        if indexPath.row == (gatheringInfos.count) - 1 {
             cell.bottomLine.isHidden = true
         }
         

--- a/GetARock/GetARock/Screen/BandInfo/VC/BandTimelineViewController.swift
+++ b/GetARock/GetARock/Screen/BandInfo/VC/BandTimelineViewController.swift
@@ -21,7 +21,7 @@ class BandTimelineViewController: UIViewController {
         tableView.register(nibName, forCellReuseIdentifier: BandTimelineCell.className)
     }
     
-    // MARK: - View Reload
+    // MARK: - Method
     
     func reloadTableView() {
         tableView.reloadData()

--- a/GetARock/GetARock/Screen/BandInfo/VC/BandTimelineViewController.swift
+++ b/GetARock/GetARock/Screen/BandInfo/VC/BandTimelineViewController.swift
@@ -39,14 +39,14 @@ extension BandTimelineViewController: UITableViewDataSource {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: BandTimelineCell.className, for: indexPath) as? BandTimelineCell else { return UITableViewCell() }
         
         let gathering = gatheringInfos[indexPath.row].gathering
-        cell.title.text = gathering.title
-        cell.startTime.text = gathering.date.toString(format: DateFormatLiteral.standard)
+        cell.titleLabel.text = gathering.title
+        cell.dateLabel.text = gathering.date.toString(format: DateFormatLiteral.standard)
         
         let statusType = gathering.status
         if statusType == .recruiting || statusType == .progressing {
-            cell.status.text = statusType.toKorean()
+            cell.statusLabel.text = statusType.toKorean()
         } else {
-            cell.status.isHidden = true
+            cell.statusLabel.isHidden = true
         }
 
         if indexPath.row == 0 {

--- a/GetARock/GetARock/Screen/BandInfo/VC/BandTimelineViewController.swift
+++ b/GetARock/GetARock/Screen/BandInfo/VC/BandTimelineViewController.swift
@@ -11,7 +11,7 @@ class BandTimelineViewController: UIViewController {
     
     // MARK: - Property
     
-    @IBOutlet weak var tableView: UITableView!
+    @IBOutlet private weak var tableView: UITableView!
     
     var gatheringInfos: [GatheringInfo] = []
     

--- a/GetARock/GetARock/Screen/BandInfo/VC/BandTimelineViewController.swift
+++ b/GetARock/GetARock/Screen/BandInfo/VC/BandTimelineViewController.swift
@@ -10,48 +10,6 @@ import UIKit
 class BandTimelineViewController: UIViewController {
     @IBOutlet weak var tableView: UITableView!
     
-    // MARK: - Sample Data
-    
-    struct Gathering {
-        enum Status: String {
-            case recruiting
-            case progressing
-            case finished
-            case canceled
-            
-            func toKorean() -> String {
-                switch self {
-                case .recruiting: return "모집중"
-                case .progressing: return "진행중"
-                case .finished: return "완료됨"
-                case .canceled: return "취소됨"
-                }
-            }
-        }
-        
-        /// 모임의 제목입니다.
-        let title: String
-        /// 모임의 진행 전/중/후 및 취소를 나타내는 상태정보입니다.
-        let status: Status
-        /// 모임이  이루어지는 날짜 및 시간입니다.
-        let date: String
-        
-        init(title: String, date: String, status: Status) {
-            self.title = title
-            self.date = date
-            self.status = status
-        }
-    }
-    
-    private var gathering = [
-        Gathering(title: "동성로 합동 버스킹 합니다!", date: "22.12.05 13:00", status: .recruiting),
-        Gathering(title: "블랙로즈 합주 드럼 한 분 구합니다", date: "22.11.20 14:00", status: .progressing),
-        Gathering(title: "몰라 아무거나 쳐보는 중입니다.", date: "22.11.20 12:00", status: .progressing),
-        Gathering(title: "두 줄 만들기 해보는 중, 몰라 아무거나 쳐보는 중입니다1234.", date: "22.11.18 21:00", status: .canceled),
-        Gathering(title: "대체텍스트 대체텍스트 대체텍스트", date: "22.11.18 16:00", status: .finished),
-        Gathering(title: "두 줄 만들기 대체텍스트 대체텍스트 대체텍스트 대체텍스트 대체텍스트 22", date: "22.11.12 18:00", status: .finished)
-    ]
-    
     // MARK: - View Life Cycle
     
     override func viewDidLoad() {
@@ -66,26 +24,27 @@ class BandTimelineViewController: UIViewController {
 
 extension BandTimelineViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return gathering.count
+//        return gathering.count
+        return 1
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: BandTimelineCell.className, for: indexPath) as? BandTimelineCell else { return UITableViewCell() }
         
-        cell.title.text = gathering[indexPath.row].title
-        cell.startTime.text = gathering[indexPath.row].date
-        let labelType = gathering[indexPath.row].status
-        if labelType == .recruiting || labelType == .progressing {
-            cell.status.text = labelType.toKorean()
-        } else {
-            cell.status.isHidden = true
-        }
-        
-        if indexPath.row == 0 {
-            cell.topLine.isHidden = true
-        } else if indexPath.row == gathering.count - 1 {
-            cell.bottomLine.isHidden = true
-        }
+//        cell.title.text = gathering[indexPath.row].title
+//        cell.startTime.text = gathering[indexPath.row].date
+//        let labelType = gathering[indexPath.row].status
+//        if labelType == .recruiting || labelType == .progressing {
+//            cell.status.text = labelType.toKorean()
+//        } else {
+//            cell.status.isHidden = true
+//        }
+//
+//        if indexPath.row == 0 {
+//            cell.topLine.isHidden = true
+//        } else if indexPath.row == gathering.count - 1 {
+//            cell.bottomLine.isHidden = true
+//        }
         
         return cell
     }

--- a/GetARock/GetARock/Screen/BandInfo/VC/BandTimelineViewController.swift
+++ b/GetARock/GetARock/Screen/BandInfo/VC/BandTimelineViewController.swift
@@ -8,6 +8,9 @@
 import UIKit
 
 class BandTimelineViewController: UIViewController {
+    
+    // MARK: - Property
+    
     @IBOutlet weak var tableView: UITableView!
     
     var gatheringInfos: [GatheringInfo] = []

--- a/GetARock/GetARock/Screen/BandInfo/VC/BandTimelineViewController.swift
+++ b/GetARock/GetARock/Screen/BandInfo/VC/BandTimelineViewController.swift
@@ -10,6 +10,8 @@ import UIKit
 class BandTimelineViewController: UIViewController {
     @IBOutlet weak var tableView: UITableView!
     
+    var gatheringInfos: [GatheringInfo] = []
+    
     // MARK: - View Life Cycle
     
     override func viewDidLoad() {
@@ -24,27 +26,28 @@ class BandTimelineViewController: UIViewController {
 
 extension BandTimelineViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-//        return gathering.count
-        return 1
+        return gatheringInfos.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: BandTimelineCell.className, for: indexPath) as? BandTimelineCell else { return UITableViewCell() }
         
-//        cell.title.text = gathering[indexPath.row].title
-//        cell.startTime.text = gathering[indexPath.row].date
-//        let labelType = gathering[indexPath.row].status
-//        if labelType == .recruiting || labelType == .progressing {
-//            cell.status.text = labelType.toKorean()
-//        } else {
-//            cell.status.isHidden = true
-//        }
-//
-//        if indexPath.row == 0 {
-//            cell.topLine.isHidden = true
-//        } else if indexPath.row == gathering.count - 1 {
-//            cell.bottomLine.isHidden = true
-//        }
+        let gathering = gatheringInfos[indexPath.row].gathering
+        cell.title.text = gathering.title
+        cell.startTime.text = gathering.date.toString(format: DateFormatLiteral.standard)
+        
+        let statusType = gathering.status
+        if statusType == .recruiting || statusType == .progressing {
+            cell.status.text = statusType.toKorean()
+        } else {
+            cell.status.isHidden = true
+        }
+
+        if indexPath.row == 0 {
+            cell.topLine.isHidden = true
+        } else if indexPath.row == (gatheringInfos.count) - 1 {
+            cell.bottomLine.isHidden = true
+        }
         
         return cell
     }


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- #108 

## 배경
<!-- PR과 관련된 논의 쓰레드, 디자인 가이드, 관련 PR 링크 등을 적어주세요 -->
내모여락 버튼 클릭 시 나오게 되는 리스트 항목 뷰를 목데이터와 연결합니다.

## 작업 내용
<!-- PR 작성 이유와 어떤 변경이 있었는지를 포함합니다. PR에 많은 변경이 있는 경우 추가되는 클래스들의 구조나 동작 등 자세하게 적는 경우도 있습니다 -->
- 밴드 타임라인 ViewController 안에 있던 임시데이터 삭제
- 이벤트 정보 리스트 값을 넘겨받을 수 있도록 변수 설정 후 MockData 형식으로 받아서 출력가능하도록 구현
- 변수에는 초기값을 넣어주면서 후처리 코드가 더 깔끔해지도록 구현
- 타임라인 progress에서 선을 표시하는 코드의 엣지케이스 오류 개선

## 테스트 방법
<!-- PR 리뷰어가 이 PR의 변경사항을 확인할 수 있는 방법을 서술합니다. 의도하는 테스트 결과도 서술하면 더 좋습니다 -->
기존 방식과 동일하게 시작 스토리보드를 "BandTimeline"으로 설정하고 실행하면 됩니다.
```
window!.rootViewController = UIStoryboard(name: "BandTimeline", bundle: nil).instantiateInitialViewController()!
```
데이터 초기값이 빈 배열이므로 값을 넣어서 확인하고 싶다면,
BandTimelineViewController.swift 에서
`var gatheringInfos: [GatheringInfo] = []`를 
`var gatheringInfos: [GatheringInfo] = MockData.gatherings`로 변경후에 실행하면 값이 들어간 화면을 볼 수 있습니다.

## 리뷰 노트
<!-- 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술합니다. 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트를 요청하는 경우에 작성합니다. -->
- 클래스 내에 reloadTableView()라는 함수를 구현해서 추후 넣어주는 데이터 값이 달라질 때 (MockData 추가, 변경 시), 리로드 할 수 있도록 구현했습니다.
- 타임라인의 prgoress를 표현하는 점과 선에서, 선을 표시하는 영역의 경우 기존 코드에서 if / else if 로 구현했기 때문에 1개의 이벤트만 있는 경우 양쪽의 선이 모두 사라지지 않고 한쪽 선만 사라지게 되는 문제가 발생합니다. 그래서 현재 if / if 구문으로 변경하여 문제는 개선했지만 효율성의 문제가 있기 때문에 나중에 개선의 여지가 있습니다. (현재 데이터가 많지 않을 것으로 예상하여 위와 같이 구현)
```
        if indexPath.row == 0 {
            cell.topLine.isHidden = true
        }
        if indexPath.row == (gatheringInfos.count) - 1 {
            cell.bottomLine.isHidden = true
        }
```

## 스크린샷
<!-- 화면 전환이나 인터랙션이 있는 경우 GIF를, 정적인 화면이라면 스크린샷을 첨부합니다. -->
<img width="300" alt="" src="https://user-images.githubusercontent.com/29690062/203697841-98b841ce-f11c-4fce-ac01-5e000f830bb4.png">