### PR TITLE
[Feat] 밴드상세화면에서 하단 상세뷰를 SegmentedControlButton과 연결합니다.

### DIFF
--- a/GetARock/GetARock/Global/Resource/Storyboards/BandInfo.storyboard
+++ b/GetARock/GetARock/Global/Resource/Storyboards/BandInfo.storyboard
@@ -13,7 +13,7 @@
         <!--Band Info View Controller-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
-                <viewController id="Y6W-OH-hqX" customClass="BandInfoViewController" customModule="GetARock" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="BandInfoViewController" id="Y6W-OH-hqX" customClass="BandInfoViewController" customModule="GetARock" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="1000"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/GetARock/GetARock/Global/Resource/Storyboards/BandTimeline.storyboard
+++ b/GetARock/GetARock/Global/Resource/Storyboards/BandTimeline.storyboard
@@ -12,7 +12,7 @@
         <!--Band Timeline View Controller-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
-                <viewController id="Y6W-OH-hqX" customClass="BandTimelineViewController" customModule="GetARock" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="BandTimelineViewController" id="Y6W-OH-hqX" customClass="BandTimelineViewController" customModule="GetARock" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/GetARock/GetARock/Screen/BandInfo/VC/BandPageViewController.swift
+++ b/GetARock/GetARock/Screen/BandInfo/VC/BandPageViewController.swift
@@ -7,6 +7,20 @@
 
 import UIKit
 
+enum BandInfoViewList: Int, CaseIterable {
+    case bandInfo
+    case bandTimeLine
+    case visitorComment
+
+    func toKorean() -> String {
+        switch self {
+        case .bandInfo: return "밴드 정보"
+        case .bandTimeLine: return "타임라인"
+        case .visitorComment: return "방명록"
+        }
+    }
+}
+
 class BandPageViewController: UIViewController {
     
     // MARK: - View

--- a/GetARock/GetARock/Screen/BandInfo/VC/BandPageViewController.swift
+++ b/GetARock/GetARock/Screen/BandInfo/VC/BandPageViewController.swift
@@ -22,16 +22,56 @@ enum BandInfoViewList: Int, CaseIterable {
 }
 
 class BandPageViewController: UIViewController {
+
+    // MARK: - Properties
+    
+    var currentPage: Int = 0 {
+        didSet {
+            let direction: UIPageViewController.NavigationDirection = oldValue <= self.currentPage ? .forward : .reverse
+            self.pageViewController.setViewControllers([viewControllerList[self.currentPage]],
+                                                       direction: direction, animated: true)
+        }
+    }
+    
+    private var bandinfo: BandInfo = MockData.bands[0]
+    
+    init(bandInfo: BandInfo) {
+        super.init(nibName: nil, bundle: nil)
+        self.bandinfo = bandInfo
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     // MARK: - View
+
+    private lazy var topView = TopViewOfInfoView(bandName: self.bandinfo.band.name,
+                                                 bandLocation: self.bandinfo.band.location.address ?? "")
+    private let segmentedControlButtons = SwitchingViewSegmentedControl(buttonTitles:
+                                                                        [BandInfoViewList.bandInfo.toKorean(),
+                                                                         BandInfoViewList.bandTimeLine.toKorean(),
+                                                                         BandInfoViewList.visitorComment.toKorean()])
+    private lazy var bandInfoViewController = UIStoryboard(name: "BandInfo", bundle: nil).instantiateViewController(withIdentifier: BandInfoViewController.className)
+    private lazy var bandTimelineViewController = UIStoryboard(name: "BandTimeline", bundle: nil).instantiateViewController(withIdentifier: BandTimelineViewController.className)
+    private lazy var commentListViewController = VisitorCommentViewController()
     
-    private let topView = TopViewOfInfoView(bandName: "블랙로즈", bandLocation: "주소다주소야주소다주소야")
+    private lazy var pageViewController: UIPageViewController = {
+        let pageViewController = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal)
+        pageViewController.setViewControllers([self.viewControllerList[0]], direction: .forward, animated: true)
+        return pageViewController
+    }()
+    
+    var viewControllerList: [UIViewController] {
+        [self.bandInfoViewController, self.bandTimelineViewController, self.commentListViewController]
+    }
     
     // MARK: - View Life Cycle
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setupLayout()
+        segmentedControlButtons.delegate = self
     }
 
 }
@@ -39,6 +79,29 @@ class BandPageViewController: UIViewController {
 // MARK: - Layout
 
 extension BandPageViewController {
+    
+    private func configurePageViewController() {
+        pageViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(pageViewController.view)
+        NSLayoutConstraint.activate([
+            pageViewController.view.topAnchor.constraint(equalTo: segmentedControlButtons.bottomAnchor, constant: 3),
+            pageViewController.view.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            pageViewController.view.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            pageViewController.view.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
+        ])
+    }
+    
+    private func configureSegmentedControlButton() {
+        segmentedControlButtons.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(segmentedControlButtons)
+        NSLayoutConstraint.activate([
+            segmentedControlButtons.topAnchor.constraint(equalTo: topView.bottomAnchor),
+            segmentedControlButtons.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            segmentedControlButtons.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            segmentedControlButtons.heightAnchor.constraint(equalToConstant: 40)
+        ])
+    }
+    
     private func configureTopView() {
         topView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(topView)
@@ -49,8 +112,21 @@ extension BandPageViewController {
             topView.heightAnchor.constraint(equalToConstant: 130)
         ])
     }
+    
     private func setupLayout() {
         view.backgroundColor = .modalBackgroundBlue
         configureTopView()
+        configureSegmentedControlButton()
+        configurePageViewController()
     }
+    
+}
+
+// MARK: - SwitchingViewSegmentedControlDelegate
+
+extension BandPageViewController: SwitchingViewSegmentedControlDelegate {
+    func segmentValueChanged(to index: Int) {
+        currentPage = index
+    }
+    
 }


### PR DESCRIPTION
## 관련 이슈
- close #82 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 배경

지도에서 밴드핀을 눌렀을 때 나오는 밴드 상세화면에서 
'밴드정보, 타임라인, 방명록"화면을 각각 SegmentedControl 버튼에 맞게 연결했습니다.
<!-- PR과 관련된 논의 쓰레드, 디자인 가이드, 관련 PR 링크 등을 적어주세요 -->

## 작업 내용

👉 이전에 만들어놓은 SwitchingViewSegmentedControl 뷰와 BandPageViewController를 연결했습니다.
👉 UIPageViewController를 이용하여 각각의 ViewController간 전환을 구현했습니다.
👉  버튼이 눌릴 때 delegate를 이용해 SwitchingViewSegmentedControl에 해당 버튼 정보를 보내어 버튼이 바뀌게끔 구현했습니다.

<!-- PR 작성 이유와 어떤 변경이 있었는지를 포함합니다. PR에 많은 변경이 있는 경우 추가되는 클래스들의 구조나 동작 등 자세하게 적는 경우도 있습니다 -->

## 테스트 방법
`SceneDelegate` - ```func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) ``` 안에 아래 코드를 넣으면 시뮬레이터에서 확인하실 수 있습니다.

``` swift
   guard let windowScene = (scene as? UIWindowScene) else { return }
                    window = UIWindow(windowScene: windowScene)
                    window?.rootViewController = BandPageViewController(bandInfo: MockData.bands[0])
                    window?.makeKeyAndVisible()
```
<!-- PR 리뷰어가 이 PR의 변경사항을 확인할 수 있는 방법을 서술합니다. 의도하는 테스트 결과도 서술하면 더 좋습니다 -->

## 리뷰 노트

- 
<!-- 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술합니다. 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트를 요청하는 경우에 작성합니다. -->

## 스크린샷
![Simulator Screen Recording - iPhone 14 Pro - 2023-01-09 at 19 55 56](https://user-images.githubusercontent.com/69718283/211292463-d2fd9b77-d8bc-4c6f-b185-aa3ee92c59d7.gif)

<!-- 화면 전환이나 인터랙션이 있는 경우 GIF를, 정적인 화면이라면 스크린샷을 첨부합니다. -->
<!-- <img width="" alt="" src=""> -->
